### PR TITLE
fix: remove unsupported pod flag

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -50,6 +50,16 @@ post_install do |installer|
       config.build_settings['PROVISIONING_PROFILE_SPECIFIER'] = ''
       config.build_settings['PROVISIONING_PROFILE'] = ''
       config.build_settings['DEVELOPMENT_TEAM'] = ''
+
+      # Remove invalid compiler flag added by some pods that causes
+      # "unsupported option '-G'" errors when building with Xcode 16.
+      # The flag appears as "-GCC_WARN_INHIBIT_ALL_WARNINGS" in OTHER_CFLAGS
+      # and needs to be stripped to avoid passing the unsupported -G option
+      # to clang.
+      flags = config.build_settings['OTHER_CFLAGS']
+      if flags.is_a?(String)
+        config.build_settings['OTHER_CFLAGS'] = flags.split(' ').reject { |f| f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }.join(' ')
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- strip `-GCC_WARN_INHIBIT_ALL_WARNINGS` from pod build flags to avoid `unsupported option '-G'` errors

## Testing
- `ruby -c ios/Podfile`
- `gem install cocoapods -N` *(fails: 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_b_6899ea2f71f48327ae8306691f6b378e