### PR TITLE
fix: strip deprecated GCC_WARN_INHIBIT_ALL_WARNINGS flag

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -51,15 +51,21 @@ post_install do |installer|
       config.build_settings['PROVISIONING_PROFILE'] = ''
       config.build_settings['DEVELOPMENT_TEAM'] = ''
 
-      # Remove invalid compiler flag added by some pods that causes
-      # "unsupported option '-G'" errors when building with Xcode 16.
-      # The flag appears as "-GCC_WARN_INHIBIT_ALL_WARNINGS" in OTHER_CFLAGS
-      # and needs to be stripped to avoid passing the unsupported -G option
-      # to clang.
-      flags = config.build_settings['OTHER_CFLAGS']
-      if flags.is_a?(String)
-        config.build_settings['OTHER_CFLAGS'] = flags.split(' ').reject { |f| f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }.join(' ')
-      end
+        # Remove invalid compiler flag added by some pods that causes
+        # "unsupported option '-G'" errors when building with Xcode 16.
+        # Some pods inject the deprecated `GCC_WARN_INHIBIT_ALL_WARNINGS`
+        # build setting which Xcode 16 turns into an unsupported `-G` flag.
+        # Strip the setting and any corresponding flag to keep clang happy.
+        config.build_settings.delete('GCC_WARN_INHIBIT_ALL_WARNINGS')
+        flags = config.build_settings['OTHER_CFLAGS']
+        case flags
+        when Array
+          config.build_settings['OTHER_CFLAGS'] =
+            flags.reject { |f| f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }
+        when String
+          config.build_settings['OTHER_CFLAGS'] =
+            flags.split(' ').reject { |f| f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' }.join(' ')
+        end
     end
   end
 end


### PR DESCRIPTION
## Summary
- remove deprecated GCC_WARN_INHIBIT_ALL_WARNINGS setting from CocoaPods build configs
- strip any -GCC_WARN_INHIBIT_ALL_WARNINGS tokens from OTHER_CFLAGS to avoid clang -G error

## Testing
- `ruby -c ios/Podfile`
- `flutter --version` *(fails: command not found)*
- `pod --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6899edc67fac8327b96b778a50906567