### PR TITLE
fix: avoid unsupported flags during iOS archive

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -147,6 +147,8 @@ jobs:
         shell: bash
         run: |
           set -e
+          # Clear environment C/C++ flags that may inject unsupported options
+          unset CFLAGS CXXFLAGS CPPFLAGS
           cd ios
           xcodebuild -workspace Runner.xcworkspace \
             -scheme Runner \


### PR DESCRIPTION
## Summary
- clear C/C++ environment flags before running `xcodebuild` in iOS workflow

## Testing
- `python3 -m pip install --quiet yamllint` *(failed: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_689a06ce77288327b02b8a4684590e2f