### PR TITLE
chore: relax pod warnings for xcode 16

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -40,8 +40,12 @@ post_install do |installer|
     target.build_configurations.each do |config|
       # Mantén el mínimo que ya estabas usando
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '15.0'
-      config.build_settings['SWIFT_VERSION'] = '5.9'
-      config.build_settings['ENABLE_BITCODE'] = 'NO'
+        config.build_settings['SWIFT_VERSION'] = '5.9'
+        config.build_settings['ENABLE_BITCODE'] = 'NO'
+        config.build_settings['SWIFT_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
+        if config.name == 'Debug'
+        config.build_settings['SWIFT_OPTIMIZATION_LEVEL'] = '-Onone'
+        end
 
       # Desactivar firma en TODOS los Pods
       config.build_settings['CODE_SIGNING_ALLOWED'] = 'NO'
@@ -63,29 +67,29 @@ post_install do |installer|
       # como errores (-Werror).  Eliminamos cualquier flag -Werror y
       # desactivamos la conversión de warnings en errores para evitar que
       # el archivado falle cuando CocoaPods incluye esas opciones.
-      config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
+        config.build_settings['GCC_TREAT_WARNINGS_AS_ERRORS'] = 'NO'
 
-      %w[OTHER_CFLAGS OTHER_CPLUSPLUSFLAGS].each do |flag|
-        # Algunos pods (como BoringSSL) declaran flags específicos para
-        # arquitecturas o SDKs, p.ej. `OTHER_CFLAGS[sdk=iphoneos*]`.  Si sólo
-        # limpiamos la clave base, esos valores permanecen y Xcode sigue
-        # tratando los warnings como errores.  Por eso iteramos sobre todas las
-        # variantes de la clave y eliminamos cualquier flag problemático.
+        %w[OTHER_CFLAGS OTHER_CPLUSPLUSFLAGS OTHER_SWIFT_FLAGS].each do |flag|
+          # Algunos pods (como BoringSSL) declaran flags específicos para
+          # arquitecturas o SDKs, p.ej. `OTHER_CFLAGS[sdk=iphoneos*]`.  Si sólo
+          # limpiamos la clave base, esos valores permanecen y Xcode sigue
+          # tratando los warnings como errores.  Por eso iteramos sobre todas las
+          # variantes de la clave y eliminamos cualquier flag problemático.
         keys = config.build_settings.keys.grep(/^#{flag}(\[[^\]]+\])?$/)
         keys.each do |key|
           current = config.build_settings[key]
-          case current
-          when Array
-            config.build_settings[key] =
-              current.reject { |f| f == '-G' || f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' || f.start_with?('-Werror') }
-          when String
-            config.build_settings[key] =
-              current.split(' ').reject { |f| f == '-G' || f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' || f.start_with?('-Werror') }.join(' ')
+            case current
+            when Array
+              config.build_settings[key] =
+                current.reject { |f| f == '-G' || f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' || f.start_with?('-Werror') }
+            when String
+              config.build_settings[key] =
+                current.split(' ').reject { |f| f == '-G' || f == '-GCC_WARN_INHIBIT_ALL_WARNINGS' || f.start_with?('-Werror') }.join(' ')
+            end
           end
         end
       end
     end
   end
-end
 
 


### PR DESCRIPTION
## Summary
- avoid treating Swift warnings as errors in CocoaPods
- strip `-Werror` flags from Swift pods and set debug optimization to `-Onone`

## Testing
- `ruby -c ios/Podfile`
- `flutter pub get` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_689a2171532c8327aceccbc051141624