### PR TITLE
chore(ci): pin xcode and verify version

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -15,15 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Select Xcode 16
+      - name: Select Xcode 15.4
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '16.*'   # o '16.2' / '16.*' según disponibilidad en el runner
-
-      - name: Check Xcode version
-        run: |
-          xcodebuild -version
-          xcrun --sdk iphoneos --show-sdk-version
+          xcode-version: '15.4'   # stable version installed on the runner
 
       - name: Setup Flutter
         uses: subosito/flutter-action@v2
@@ -32,6 +27,17 @@ jobs:
 
       - name: Flutter pub get
         run: flutter pub get
+
+      - name: Verify Xcode version
+        run: |
+          EXPECTED="Xcode 15.4"
+          ACTUAL=$(xcodebuild -version | head -n 1)
+          echo "$ACTUAL"
+          if [[ "$ACTUAL" != "$EXPECTED" ]]; then
+            echo "Expected $EXPECTED but found $ACTUAL"
+            exit 1
+          fi
+          xcrun --sdk iphoneos --show-sdk-version
 
       - name: Install CocoaPods
         run: |


### PR DESCRIPTION
## Summary
- pin Xcode to 15.4 in iOS unsigned workflow
- verify selected Xcode version before installing CocoaPods

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689a27b91b3083278f7922fb98287bf7