### PR TITLE
chore: update ios build config for github action

### DIFF
--- a/.github/workflows/ios-unsigned.yml
+++ b/.github/workflows/ios-unsigned.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install CocoaPods
         run: |
-          sudo gem install cocoapods -N
+          sudo gem install cocoapods -v 1.15.2 -N
           cd ios
           # Update the CocoaPods repo to ensure podspec patches like the
           # removal of deprecated `GCC_WARN_INHIBIT_ALL_WARNINGS` are pulled in.
@@ -151,6 +151,9 @@ jobs:
             grep -q 'Generated.xcconfig' "$cfg" || echo '#include? "Generated.xcconfig"' >> "$cfg"
           done
           grep ^FLUTTER_ROOT ios/Flutter/Generated.xcconfig
+
+      - name: Flutter build (no codesign)
+        run: flutter build ios --release --no-codesign
 
       - name: Archive with xcodebuild (unsigned)
         shell: bash

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -28,13 +28,14 @@ require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelpe
 flutter_ios_podfile_setup
 
 target 'Runner' do
-  use_frameworks!
+  use_frameworks! :linkage => :static
   use_modular_headers!
 
   pod 'Firebase/Analytics', :modular_headers => true
   pod 'Firebase/Auth', :modular_headers => true
   pod 'Firebase/Core', :modular_headers => true
   pod 'Firebase/Firestore', :modular_headers => true
+  pod 'Firebase/Messaging', :modular_headers => true
 
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
@@ -46,6 +47,9 @@ end
 post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
+    target.build_configurations.each do |config|
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+    end
     if target.name == 'BoringSSL-GRPC'
       target.source_build_phase.files.each do |file|
         if file.settings && file.settings['COMPILER_FLAGS']

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,10 +10,10 @@ dependencies:
   flutter:
     sdk: flutter
 
-  firebase_core: 2.27.0
-  firebase_auth: 4.17.8
-  cloud_firestore: 4.15.8
-  firebase_messaging: 14.7.19
+  firebase_core: ^2.27.1
+  firebase_auth: ^4.17.9
+  cloud_firestore: ^4.15.9
+  firebase_messaging: ^14.7.21
 
 # Pod build fix for Xcode 16
 # Keeping firebase packages current ensures their podspecs do not include


### PR DESCRIPTION
## Summary
- bump Firebase packages
- use static frameworks and raise deployment target for pods
- ensure workflow installs CocoaPods 1.15 and runs `flutter build ios`

## Testing
- `flutter pub get` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689ad8e0a25883279ef5f96a54a2a206