### PR TITLE
fix: include Firebase modular header

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,6 +31,7 @@ target 'Runner' do
   use_frameworks! :linkage => :static
   use_modular_headers!
 
+  pod 'Firebase', :modular_headers => true
   pod 'Firebase/Analytics', :modular_headers => true
   pod 'Firebase/Auth', :modular_headers => true
   pod 'Firebase/Core', :modular_headers => true


### PR DESCRIPTION
## Summary
- add Firebase meta pod as modular header to avoid non-modular include error

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689ae0e03f608327981cb2d7a47876de