### PR TITLE
chore: simplify iOS Podfile

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -31,13 +31,6 @@ target 'Runner' do
   use_frameworks! :linkage => :static
   use_modular_headers!
 
-  pod 'Firebase', :modular_headers => true
-  pod 'Firebase/Analytics', :modular_headers => true
-  pod 'Firebase/Auth', :modular_headers => true
-  pod 'Firebase/Core', :modular_headers => true
-  pod 'Firebase/Firestore', :modular_headers => true
-  pod 'Firebase/Messaging', :modular_headers => true
-
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
 
   target 'RunnerTests' do
@@ -50,6 +43,7 @@ post_install do |installer|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
     end
     if target.name == 'BoringSSL-GRPC'
       target.source_build_phase.files.each do |file|


### PR DESCRIPTION
## Summary
- remove explicit Firebase pod declarations so Flutter handles Firebase dependencies
- enable non-modular includes by setting `CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES`

## Testing
- `pod install` *(fails: command not found)*
- `gem install cocoapods` *(fails: 403 "Forbidden" error)*

------
https://chatgpt.com/codex/tasks/task_b_689ae6ebda388327ba6f2b34a8f6e990