### PR TITLE
fix ios build issue by setting c++20

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -44,6 +44,7 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
       config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
+      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
     end
     if target.name == 'BoringSSL-GRPC'
       target.source_build_phase.files.each do |file|


### PR DESCRIPTION
## Summary
- set gRPC pods to build with C++20 to fix template parse error during iOS builds

## Testing
- `flutter test` *(fails: bash: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_689aff2c694c83279f443f41aefe58a7