### PR TITLE
chore: force c++17 and log pod versions

### DIFF
--- a/ios/Podfile
+++ b/ios/Podfile
@@ -1,5 +1,5 @@
 # Uncomment this line to define a global platform for your project
-platform :ios, '13.0'
+platform :ios, '12.0'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -42,9 +42,9 @@ post_install do |installer|
   installer.pods_project.targets.each do |target|
     flutter_additional_ios_build_settings(target)
     target.build_configurations.each do |config|
-      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '12.0'
       config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
-      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
+      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
     end
     if target.name == 'BoringSSL-GRPC'
       target.source_build_phase.files.each do |file|

--- a/post-build.sh
+++ b/post-build.sh
@@ -12,15 +12,17 @@ ls ios >> build_log.txt 2>&1
 echo "[3] Intentando pod install..." >> build_log.txt
 cd ios
 pod install >> ../build_log.txt 2>&1
+echo "[4] Versiones de gRPC/BoringSSL/abseil/Firebase:" >> ../build_log.txt
+grep -E "gRPC|BoringSSL|abseil|Firebase" Podfile.lock >> ../build_log.txt 2>&1
 cd ..
 
-echo "[4] flutter pub get..." >> build_log.txt
+echo "[5] flutter pub get..." >> build_log.txt
 flutter pub get >> build_log.txt 2>&1
 
-echo "[5] Contenido de .flutter-plugins-dependencies:" >> build_log.txt
+echo "[6] Contenido de .flutter-plugins-dependencies:" >> build_log.txt
 cat .flutter-plugins-dependencies >> build_log.txt 2>&1
 
-echo "[6] Contenido de pubspec.yaml:" >> build_log.txt
+echo "[7] Contenido de pubspec.yaml:" >> build_log.txt
 cat pubspec.yaml >> build_log.txt 2>&1
 
 echo "===== POST BUILD SCRIPT FINALIZADO =====" >> build_log.txt


### PR DESCRIPTION
## Summary
- pin iOS pods to C++17 and deployment target 12.0
- log Firebase/gRPC/BoringSSL/abseil versions during CI post-build

## Testing
- `bash post-build.sh` *(fails: flutter: command not found, pod: command not found, grep: Podfile.lock: No such file or directory)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689b03bef8b88327ac6cfb068a473299