### PR TITLE
chore: prepare codemagic build for iOS 18

### DIFF
--- a/ExportOptions.plist
+++ b/ExportOptions.plist
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
- "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>method</key>
-  <string>app-store</string>
-</dict>
-</plist>

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1,23 +1,27 @@
 workflows:
-  ios-release:
-    name: iOS Release
+  ios_release:
+    name: iOS Release (Xcode 16.2)
     environment:
-      flutter: stable
       xcode: 16.2
-      cocoapods: 1.16.2
+      flutter: stable
+      vars:
+        BUNDLE_ID: com.example.sansebassms
       groups:
         - app_store_connect
     scripts:
-      - name: Pre-build
-        script: ./pre-build.sh
-      - name: Build IPA
-        script: flutter build ipa --release --export-options-plist ExportOptions.plist
-      - name: Publish to TestFlight
+      - name: Pre-build (deps, pods, firma)
         script: |
-          app-store-connect publish \
-            --api-key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-            --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-            --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
-            build/ios/ipa/*.ipa
+          chmod +x ./pre-build.sh
+          ./pre-build.sh
+      - name: Build IPA (Release, firma Distribución)
+        script: |
+          flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
     artifacts:
       - build/ios/ipa/*.ipa
+      - artifacts/*
+    publishing:
+      app_store_connect:
+        api_key: $APP_STORE_CONNECT_PRIVATE_KEY
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
+        submit_to_testflight: true

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -44,13 +44,11 @@ post_install do |installer|
     target.build_configurations.each do |config|
       config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '18.0'
       config.build_settings['CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES'] = 'YES'
-      # gRPC's core library now leverages C++20 features such as concepts and
-      # requires expressions. Building with an older C++ standard causes parse
-      # errors like "A template argument list is expected after a name prefixed by the template keyword"
-      # during the iOS archive step. Explicitly compiling Pods with the C++20
-      # standard resolves these issues while remaining compatible with the rest
-      # of the project.
-      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++20'
+      # Build CocoaPods with the C++17 standard. gRPC and some transitive
+      # dependencies still rely on APIs such as std::result_of that were removed
+      # in C++20, so targeting C++17 avoids the Clang compilation errors
+      # encountered during the iOS archive step.
+      config.build_settings['CLANG_CXX_LANGUAGE_STANDARD'] = 'c++17'
     end
     if target.name == 'BoringSSL-GRPC'
       target.source_build_phase.files.each do |file|

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -1,15 +1,34 @@
-#!/bin/bash
-set -euo pipefail
+#!/usr/bin/env bash
+set -e
 
-echo "===== PRE BUILD SCRIPT STARTED ====="
+echo "Flutter: $(flutter --version)"
+echo "Ruby: $(ruby -v)"
+echo "CocoaPods: $(pod --version)"
+xcodebuild -version
 
-# Ensure dependencies are up to date
-flutter clean
+# 1) Flutter deps
 flutter pub get
+flutter precache --ios
 
-# Prepare CocoaPods dependencies
+# 2) Force iOS 18 in Runner (project file)
+/usr/bin/sed -i '' -E "s/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+/IPHONEOS_DEPLOYMENT_TARGET = 18.0/g" ios/Runner.xcodeproj/project.pbxproj
+
+# 3) Clean and install Pods
 cd ios
+rm -rf Pods Podfile.lock
 pod install --repo-update
 cd ..
 
-echo "===== PRE BUILD SCRIPT FINISHED ====="
+# 4) Automatic distribution signing
+app-store-connect fetch-signing-files "$BUNDLE_ID" --type IOS_APP_STORE --create
+keychain initialize
+keychain add-certificates
+xcode-project use-profiles
+
+# 5) Signing diagnostics
+security find-identity -v -p codesigning || true
+ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
+
+# 6) Collect useful artifacts
+mkdir -p artifacts
+cp ios/Podfile.lock artifacts/ || true


### PR DESCRIPTION
## Summary
- prepare pre-build script for Codemagic automatic signing and iOS 18
- configure Codemagic workflow to build signed iOS release and publish to TestFlight
- compile Pods with C++17 to avoid gRPC Clang errors

## Testing
- `flutter pub get` *(fails: flutter: command not found)*
- `BUNDLE_ID=com.example.sansebassms ./pre-build.sh` *(fails: flutter: command not found, pod: command not found, xcodebuild: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cb4ce66a08327909704bd187b1012