### PR TITLE
chore: add Codemagic pre-build logging and env checks

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -7,18 +7,19 @@ workflows:
       vars:
         BUNDLE_ID: com.example.sansebassms
       groups:
-        - app_store_connect # Contains APP_STORE_CONNECT_* and related signing variables
+        - app_store_connect
     scripts:
-      - name: Pre-build (deps, pods, firma)
+      - name: Pre-build (deps, pods, firma, logging)
         script: |
           chmod +x ./pre-build.sh
           ./pre-build.sh
-      - name: Build IPA (Release, firma Distribución)
+      - name: Build IPA (Release)
         script: |
           flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
     artifacts:
       - build/ios/ipa/*.ipa
       - artifacts/*
+      - codemagic_prebuild.log
     publishing:
       app_store_connect:
         api_key: $APP_STORE_CONNECT_PRIVATE_KEY

--- a/docs/codemagic-env.example.md
+++ b/docs/codemagic-env.example.md
@@ -1,0 +1,14 @@
+# Codemagic App Store Connect environment variables (example)
+
+Define the following variables in Codemagic under **App settings → Environment variables** inside a group named `app_store_connect`:
+
+```
+APP_STORE_CONNECT_ISSUER_ID=...
+APP_STORE_CONNECT_KEY_IDENTIFIER=...
+APP_STORE_CONNECT_PRIVATE_KEY=*** (contenido del .p8) ***
+APPLE_TEAM_ID=...
+APP_STORE_APPLE_ID=...
+BUNDLE_ID=com.tu.bundle
+```
+
+Use placeholders here; do not commit secrets.

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -1,44 +1,50 @@
 #!/usr/bin/env bash
-set -e
+set -Eeuo pipefail
 
-echo "Flutter: $(flutter --version)"
-echo "Ruby: $(ruby -v)"
-echo "CocoaPods: $(pod --version)"
-xcodebuild -version
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$ROOT_DIR/codemagic_prebuild.log"
+: > "$LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
-# 1) Flutter deps
+require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "ERROR: Missing required env var: $name"
+    echo "Sugerencia: define $name en Codemagic → App settings → Environment variables (grupo app_store_connect)."
+    return 1
+  fi
+}
+
+if ! require_env APP_STORE_CONNECT_ISSUER_ID \
+     || ! require_env APP_STORE_CONNECT_KEY_IDENTIFIER \
+     || ! require_env APP_STORE_CONNECT_PRIVATE_KEY \
+     || ! require_env BUNDLE_ID; then
+  echo "Pre-build abortado por credenciales incompletas."
+  mkdir -p artifacts
+  cp "$LOG_FILE" artifacts/ || true
+  exit 2
+fi
+
+echo "Flutter: $(flutter --version)"; echo "Ruby: $(ruby -v)"; echo "CocoaPods: $(pod --version)"; xcodebuild -version
+
 flutter pub get
 flutter precache --ios
 
-# 2) Ensure Runner project targets iOS 15.0 minimum
-/usr/bin/sed -i '' -E \
-  "s/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+/IPHONEOS_DEPLOYMENT_TARGET = 15.0/g" \
-  ios/Runner.xcodeproj/project.pbxproj
+/usr/bin/sed -i '' -E "s/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]+/IPHONEOS_DEPLOYMENT_TARGET = 15.0/g" ios/Runner.xcodeproj/project.pbxproj
 
-# 3) Clean and install Pods
 cd ios
 rm -rf Pods Podfile.lock
 pod install --repo-update
-# Quick verification of pod and xcconfig resolution
-grep -E "Pods-Runner\.(debug|release|profile)\.xcconfig" Flutter/*.xcconfig || true
-grep -E "BoringSSL|gRPC|Firebase|abseil" Podfile.lock || true
 cd ..
 
-# 4) Automatic distribution signing
-# Check required App Store Connect variables are present
-: "${APP_STORE_CONNECT_ISSUER_ID:?Missing APP_STORE_CONNECT_ISSUER_ID}"
-: "${APP_STORE_CONNECT_KEY_IDENTIFIER:?Missing APP_STORE_CONNECT_KEY_IDENTIFIER}"
-: "${APP_STORE_CONNECT_PRIVATE_KEY:?Missing APP_STORE_CONNECT_PRIVATE_KEY}"
-echo "Using App Store Connect issuer: $APP_STORE_CONNECT_ISSUER_ID"
 app-store-connect fetch-signing-files "$BUNDLE_ID" --type IOS_APP_STORE --create
 keychain initialize
 keychain add-certificates
 xcode-project use-profiles
 
-# 5) Signing diagnostics
 security find-identity -v -p codesigning || true
 ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
-
-# 6) Collect useful artifacts
 mkdir -p artifacts
+grep -E "BoringSSL|gRPC|Firebase|abseil" ios/Podfile.lock | tee artifacts/pods-versions.txt || true
 cp ios/Podfile.lock artifacts/ || true
+cp "$LOG_FILE" artifacts/ || true


### PR DESCRIPTION
## Summary
- add detailed pre-build logging with environment variable validation
- document required Codemagic App Store Connect environment variables
- update codemagic workflow to publish pre-build logs

## Testing
- `bash -n pre-build.sh`
- `yamllint codemagic.yaml` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cbfcd353c83278ba014cbee15fb5e