### PR TITLE
ci: idempotent signing setup with logging

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$ROOT_DIR/codemagic_build_ipa.log"
+: > "$LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "== Build IPA =="
+flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
+
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
+echo "Build IPA DONE"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,70 +16,16 @@ workflows:
           ./pre-build.sh
       - name: Setup signing
         script: |
-          set -e
-          keychain create
-          keychain activate
-          if [ -n "${CERTIFICATE_P12_BASE64:-}" ] && [ -n "${P12_PASSWORD:-}" ]; then
-            echo "$CERTIFICATE_P12_BASE64" | base64 -d > cert.p12
-            keychain add-certificates --certificate cert.p12 --certificate-password "$P12_PASSWORD"
-            if [ -n "${PROVISIONING_PROFILE_BASE64:-}" ]; then
-              mkdir -p ~/signing
-              echo "$PROVISIONING_PROFILE_BASE64" | base64 -d > ~/signing/app.mobileprovision
-            else
-              app-store-connect fetch-signing-files \
-                --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-                --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-                --key "$APP_STORE_CONNECT_PRIVATE_KEY" \
-                --type IOS_APP_STORE \
-                --bundle-id "$BUNDLE_ID" \
-                --output ~/signing
-            fi
-          else
-            app-store-connect fetch-signing-files \
-              --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-              --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-              --key "$APP_STORE_CONNECT_PRIVATE_KEY" \
-              --type IOS_APP_STORE \
-              --bundle-id "$BUNDLE_ID" \
-              --output ~/signing
-            CERT_PATH=$(find ~/signing -name "*.p12" -print -quit || true)
-            if [ -z "$CERT_PATH" ]; then
-              echo "No distribution certificate with private key found. Creating a new one."
-              openssl genrsa -out ~/signing/dist.key 2048
-              openssl req -new -key ~/signing/dist.key -out ~/signing/dist.csr -subj "/CN=Codemagic"
-              app-store-connect certificates create \
-                --type IOS_DISTRIBUTION \
-                --csr-file ~/signing/dist.csr \
-                --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-                --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-                --key "$APP_STORE_CONNECT_PRIVATE_KEY" \
-                --output ~/signing/dist.cer
-              if [ -z "${P12_PASSWORD:-}" ]; then
-                P12_PASSWORD="$(openssl rand -base64 12)"
-              fi
-              openssl pkcs12 -export \
-                -inkey ~/signing/dist.key \
-                -in ~/signing/dist.cer \
-                -out ~/signing/dist.p12 \
-                -passout pass:"$P12_PASSWORD"
-              CERT_PATH=~/signing/dist.p12
-              CERT_PASS="$P12_PASSWORD"
-            else
-              CERT_PASS=$(cat ~/signing/certificate_password.txt)
-            fi
-            keychain add-certificates --certificate "$CERT_PATH" --certificate-password "$CERT_PASS"
-          fi
-          xcode-project use-profiles --signing-settings ~/signing
-          security find-identity -v -p codesigning > codesign_diag.log
-          security find-generic-password -a "Apple Distribution" >> codesign_diag.log 2>&1
-      - name: Build IPA (Release)
+          ./setup-signing.sh
+      - name: Build IPA
         script: |
-          flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
+          ./build-ipa.sh
     artifacts:
       - build/ios/ipa/*.ipa
+      - codemagic_prebuild.log
+      - codemagic_setup_signing.log
+      - codemagic_build_ipa.log
       - artifacts/*
-      - prebuild.log
-      - codesign_diag.log
     publishing:
       app_store_connect:
         api_key: $APP_STORE_CONNECT_PRIVATE_KEY

--- a/setup-signing.sh
+++ b/setup-signing.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$ROOT_DIR/codemagic_setup_signing.log"
+: > "$LOG_FILE"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+echo "== Setup signing =="
+
+# Vars requeridas
+require() { local n="$1"; [ -n "${!n:-}" ] || { echo "ERROR: falta $n"; exit 2; }; }
+require APPLE_TEAM_ID
+require BUNDLE_ID
+
+# Creamos llavero efímero (NUNCA el login)
+KEYCHAIN_DIR="$HOME/Library/codemagic-cli-tools/keychains"
+mkdir -p "$KEYCHAIN_DIR"
+KEYCHAIN_NAME="cm_$(date +%s)_$$.keychain-db"
+KEYCHAIN_PATH="$KEYCHAIN_DIR/$KEYCHAIN_NAME"
+KEYCHAIN_PASSWORD="${KEYCHAIN_PASSWORD:-cm_tmp_$(date +%s)}"
+
+echo "Creando llavero efímero: $KEYCHAIN_PATH"
+security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" || true
+security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH" || true
+security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+# Opción manual: P12 aportado por env
+if [ -n "${CERTIFICATE_P12_BASE64:-}" ]; then
+  echo "Importando P12 aportado…"
+  echo "$CERTIFICATE_P12_BASE64" | base64 --decode > dist.p12
+  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
+  security import dist.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign
+fi
+
+# Opción automática: usar lo descargado por pre-build (fetch-signing-files)
+# y/o reintentar importación genérica.
+if ! security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -q "Apple Distribution"; then
+  echo "Intentando importar certificados con keychain add-certificates…"
+  keychain add-certificates --keychain "$KEYCHAIN_PATH" || true
+fi
+
+# Diagnóstico: debe existir al menos 1 identidad válida
+echo "Identidades de firma en $KEYCHAIN_PATH:"
+security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+
+# Aplicamos perfiles al proyecto (usa perfiles de ~/Library/MobileDevice/Provisioning Profiles)
+echo "Aplicando perfiles con xcode-project use-profiles…"
+xcode-project use-profiles --keychain "$KEYCHAIN_PATH"
+
+# Más diagnóstico útil
+ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
+
+# Exportar log como artifact
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
+echo "Setup signing DONE"


### PR DESCRIPTION
## Summary
- add setup-signing.sh to create unique ephemeral keychain and apply profiles
- add build-ipa.sh script to build IPA with persistent logs
- invoke new scripts in codemagic workflow and expose logs as artifacts

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cdea316e08327a743ed196685bbc5