### PR TITLE
chore: streamline Codemagic signing and build process

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -1,13 +1,10 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
-ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-LOG_FILE="$ROOT_DIR/codemagic_build_ipa.log"
-: > "$LOG_FILE"
-exec > >(tee -a "$LOG_FILE") 2>&1
+set -euo pipefail
+
+exec > >(tee -a codemagic_build_ipa.log) 2>&1
 
 echo "== Build IPA =="
-flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 
-mkdir -p artifacts
-cp "$LOG_FILE" artifacts/ || true
-echo "Build IPA DONE"
+xcode-project use-profiles --project ios/Runner.xcodeproj
+xcode-project build-ipa --project ios/Runner.xcodeproj --scheme Runner
+

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -9,6 +9,7 @@ workflows:
         BUNDLE_ID: com.example.sansebassms
       groups:
         - app_store_connect
+        - ios_signing
     scripts:
       - name: Pre-build (deps, pods, firma, logging)
         script: |
@@ -16,16 +17,15 @@ workflows:
           ./pre-build.sh
       - name: Setup signing
         script: |
-          ./setup-signing.sh
+          bash -xe ./setup-signing.sh
       - name: Build IPA
         script: |
-          ./build-ipa.sh
+          bash -xe ./build-ipa.sh
     artifacts:
       - build/ios/ipa/*.ipa
-      - codemagic_prebuild.log
+      - build/ios/ipa/*.dSYM.zip
       - codemagic_setup_signing.log
       - codemagic_build_ipa.log
-      - artifacts/*
     publishing:
       app_store_connect:
         api_key: $APP_STORE_CONNECT_PRIVATE_KEY

--- a/setup-signing.sh
+++ b/setup-signing.sh
@@ -1,72 +1,55 @@
 #!/usr/bin/env bash
-set -Eeuo pipefail
+set -euo pipefail
 
-ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-LOG_FILE="$ROOT_DIR/codemagic_setup_signing.log"
-: > "$LOG_FILE"
-exec > >(tee -a "$LOG_FILE") 2>&1
+exec > >(tee -a codemagic_setup_signing.log) 2>&1
 
 echo "== Setup signing =="
 
-require() { local n="$1"; [ -n "${!n:-}" ] || { echo "ERROR: falta $n"; exit 2; }; }
-require APPLE_TEAM_ID
-require BUNDLE_ID
+# Validate required environment variables
+require() {
+  local var="$1"
+  if [ -z "${!var:-}" ]; then
+    echo "Missing $var" >&2
+    exit 2
+  fi
+}
 
-# Create ephemeral keychain (never touch login)
-KEYCHAIN_DIR="$HOME/Library/codemagic-cli-tools/keychains"
-mkdir -p "$KEYCHAIN_DIR"
-KEYCHAIN_NAME="cm_$(date +%s)_$$.keychain-db"
-KEYCHAIN_PATH="$KEYCHAIN_DIR/$KEYCHAIN_NAME"
-KEYCHAIN_PASSWORD="${KEYCHAIN_PASSWORD:-cm_tmp_$(date +%s)}"
+for v in APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_IDENTIFIER APP_STORE_CONNECT_PRIVATE_KEY BUNDLE_ID TEAM_ID; do
+  require "$v"
+done
 
-echo "Creando llavero efímero: $KEYCHAIN_PATH"
-security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH" || true
-security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH" || true
-security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-
-# Make it default and only one in search list
-security list-keychains -d user -s "$KEYCHAIN_PATH"
-security default-keychain -s "$KEYCHAIN_PATH"
-
-# Optional manual import via P12 provided in env vars
-if [ -n "${CERTIFICATE_P12_BASE64:-}" ]; then
-  echo "Importando P12 aportado…"
-  echo "$CERTIFICATE_P12_BASE64" | base64 --decode > dist.p12
-  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
-  security import dist.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign
+# APPLE_CERTIFICATE_PRIVATE_KEY required unless using manual P12
+if [ -z "${CERTIFICATE_PATH:-}" ]; then
+  require APPLE_CERTIFICATE_PRIVATE_KEY
 fi
 
-# Import certificates downloaded by fetch-signing-files
-echo "Importando certificados con keychain add-certificates…"
-keychain add-certificates || true
+# Initialize ephemeral/default keychain
+keychain initialize
 
-# Check for identities
-IDS="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -cE 'Apple (Distribution|Development)' || true)"
-echo "Identidades encontradas: $IDS"
-if [ "${IDS:-0}" -eq 0 ]; then
-  echo "Sin identidades válidas. Generando certificado de distribución temporal…"
-  TMP_DIR="$(mktemp -d)"
-  pushd "$TMP_DIR" >/dev/null
-  openssl req -new -newkey rsa:2048 -nodes -keyout temp.key -out temp.csr -subj "/CN=Codemagic/OU=${APPLE_TEAM_ID}/O=${APPLE_TEAM_ID}/C=US"
-  app-store-connect certificates create \
-    --type IOS_DISTRIBUTION \
-    --csr-file temp.csr \
-    --certificate-output-file temp.cer
-  openssl x509 -in temp.cer -out temp.pem -inform DER
-  P12_PWD="${P12_PASSWORD:-temp_pass}"
-  openssl pkcs12 -export -inkey temp.key -in temp.pem -out temp.p12 -password "pass:$P12_PWD"
-  security import temp.p12 -k "$KEYCHAIN_PATH" -P "$P12_PWD" -T /usr/bin/codesign
-  popd >/dev/null
+if [ -n "${CERTIFICATE_PATH:-}" ] && [ -n "${CERTIFICATE_PASSWORD:-}" ]; then
+  echo "Importing provided P12 certificate"
+  keychain add-certificates --certificate "$CERTIFICATE_PATH" --certificate-password @env:CERTIFICATE_PASSWORD
+else
+  echo "Fetching signing files from App Store Connect"
+  if app-store-connect fetch-signing-files --help 2>&1 | grep -q -- '--create'; then
+    app-store-connect fetch-signing-files \
+      --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID \
+      --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER \
+      --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
+      --certificate-key @env:APPLE_CERTIFICATE_PRIVATE_KEY \
+      @env:BUNDLE_ID \
+      --create
+  else
+    app-store-connect fetch-signing-files \
+      --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID \
+      --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER \
+      --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
+      --certificate-key @env:APPLE_CERTIFICATE_PRIVATE_KEY \
+      @env:BUNDLE_ID
+  fi
 fi
 
-# Final diagnostics
-security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
-ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
+# Show resulting certificates and profiles
+ls -la "$HOME/Library/MobileDevice/Certificates" || true
+ls -la "$HOME/Library/MobileDevice/Provisioning Profiles" || true
 
-# Apply provisioning profiles using default keychain
-xcode-project use-profiles || true
-
-mkdir -p artifacts
-cp "$LOG_FILE" artifacts/ || true
-
-echo "Setup signing DONE"


### PR DESCRIPTION
## Summary
- add setup-signing.sh using codemagic CLI to fetch signing files and log outputs
- add build-ipa.sh with profile application and IPA build logging
- update codemagic.yaml workflow to use new scripts, include ios_signing group and publish logs

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689ce6aa3e288327841928c9fe8c19af