### PR TITLE
feat: improve signing setup

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-exec > >(tee -a codemagic_build_ipa.log) 2>&1
+set -Eeuo pipefail
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$ROOT_DIR/codemagic_build_ipa.log"
+: > "$LOG_FILE"; exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "== Build IPA =="
+# Aplica perfiles al proyecto (usa el default keychain fijado por 'keychain initialize')
+xcode-project use-profiles
+flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 
-xcode-project use-profiles --project ios/Runner.xcodeproj
-xcode-project build-ipa --project ios/Runner.xcodeproj --scheme Runner
-
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
+echo "Build IPA DONE"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -10,21 +10,20 @@ workflows:
         APPLE_TEAM_ID: 7QWJ8R3ZB5
         CERTIFICATE_P12_BASE64: $CERTIFICATE_P12_BASE64
         P12_PASSWORD: $P12_PASSWORD
-        KEYCHAIN_PASSWORD: $KEYCHAIN_PASSWORD
       groups:
         - app_store_connect
     scripts:
       - name: Pre-build (deps, pods, firma, logging)
         script: |
-          chmod +x ./pre-build.sh
+          chmod +x pre-build.sh
           ./pre-build.sh
       - name: Setup signing
         script: |
-          chmod +x ./setup-signing.sh
+          chmod +x setup-signing.sh
           ./setup-signing.sh
       - name: Build IPA
         script: |
-          chmod +x ./build-ipa.sh
+          chmod +x build-ipa.sh
           ./build-ipa.sh
     artifacts:
       - build/ios/ipa/*.ipa

--- a/setup-signing.sh
+++ b/setup-signing.sh
@@ -1,44 +1,50 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
-exec > >(tee -a codemagic_setup_signing.log) 2>&1
+set -Eeuo pipefail
+ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+LOG_FILE="$ROOT_DIR/codemagic_setup_signing.log"
+: > "$LOG_FILE"; exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "== Setup signing =="
 
-# Validate required environment variables
-require() {
-  local var="$1"
-  if [ -z "${!var:-}" ]; then
-    echo "Missing $var" >&2
-    exit 2
-  fi
-}
+# Vars mínimas
+require(){ local n="$1"; [ -n "${!n:-}" ] || { echo "ERROR: falta $n"; exit 2; }; }
+require APPLE_TEAM_ID
+require BUNDLE_ID
 
-for v in APP_STORE_CONNECT_ISSUER_ID APP_STORE_CONNECT_KEY_IDENTIFIER APP_STORE_CONNECT_PRIVATE_KEY BUNDLE_ID APPLE_TEAM_ID; do
-  require "$v"
-done
+# Inicializar llavero efímero (usar CLI oficial de Codemagic)
+keychain initialize
+KEYCHAIN_PATH="$(keychain get-default | tail -n1 | awk '{print $NF}')"
+echo "Default keychain: $KEYCHAIN_PATH"
 
-# Initialize ephemeral/default keychain
-if [ -n "${KEYCHAIN_PASSWORD:-}" ]; then
-  keychain initialize --password "$KEYCHAIN_PASSWORD"
-else
-  keychain initialize
+# 1) Ruta MANUAL: si el usuario aporta un P12 en base64, importarlo con 'security import'
+if [ -n "${CERTIFICATE_P12_BASE64:-}" ]; then
+  echo "Importando P12 aportado…"
+  echo "$CERTIFICATE_P12_BASE64" | base64 --decode > dist.p12
+  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
+  security import dist.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign
 fi
 
-if [ -n "${CERTIFICATE_P12_BASE64:-}" ] && [ -n "${P12_PASSWORD:-}" ]; then
-  echo "Importing provided P12 certificate"
-  keychain add-certificates --certificate-base64 "$CERTIFICATE_P12_BASE64" --certificate-password "$P12_PASSWORD"
-else
-  echo "Fetching signing files from App Store Connect"
-  app-store-connect fetch-signing-files \
-    --issuer-id @env:APP_STORE_CONNECT_ISSUER_ID \
-    --key-id @env:APP_STORE_CONNECT_KEY_IDENTIFIER \
-    --private-key @env:APP_STORE_CONNECT_PRIVATE_KEY \
-    --team-id @env:APPLE_TEAM_ID \
-    @env:BUNDLE_ID
+# 2) Si aún no hay identidades, usar fetch-signing-files (auto)
+HAS_IDS="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -cE 'Apple (Distribution|Development)' || true)"
+if [ "${HAS_IDS:-0}" -eq 0 ]; then
+  echo "Sin identidades válidas; obteniendo firma desde App Store Connect…"
+  : "${APP_STORE_CONNECT_ISSUER_ID:?}"; : "${APP_STORE_CONNECT_KEY_IDENTIFIER:?}"; : "${APP_STORE_CONNECT_PRIVATE_KEY:?}"
+  app-store-connect fetch-signing-files "$BUNDLE_ID" \
+    --type IOS_APP_STORE \
+    --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
+    --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+    --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
+    --create
+  # Importar lo que descargó fetch-signing-files
+  keychain add-certificates || true
 fi
 
-# Show resulting certificates and profiles
-ls -la "$HOME/Library/MobileDevice/Certificates" || true
-ls -la "$HOME/Library/MobileDevice/Provisioning Profiles" || true
+echo "Identidades de firma:"
+security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
 
+echo "Perfiles disponibles:"
+ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
+
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
+echo "Setup signing DONE"


### PR DESCRIPTION
## Summary
- rework signing setup to support P12 via security import and fallback to ASC fetch
- add logging around IPA build and use flutter build
- simplify codemagic workflow and remove unsupported keychain flags

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689cee6fd3108327b780572f33b0129c