### PR TITLE
feat: robust signing setup fallback

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -9,6 +9,6 @@ echo "== Build IPA =="
 xcode-project use-profiles
 flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 
-mkdir -p artifacts
-cp "$LOG_FILE" artifacts/ || true
+mkdir -p "$ROOT_DIR/artifacts"
+cp "$LOG_FILE" "$ROOT_DIR/artifacts/" || true
 echo "Build IPA DONE"

--- a/setup-signing.sh
+++ b/setup-signing.sh
@@ -11,31 +11,39 @@ require(){ local n="$1"; [ -n "${!n:-}" ] || { echo "ERROR: falta $n"; exit 2; }
 require APPLE_TEAM_ID
 require BUNDLE_ID
 
+import_p12_from_env() {
+  [ -n "${CERTIFICATE_P12_BASE64:-}" ] || return 1
+  echo "Importando P12 aportado…"
+  # Guardado y sanitizado mínimo (ignora basura si hubiera)
+  if ! printf "%s" "$CERTIFICATE_P12_BASE64" | base64 --decode --ignore-garbage > dist.p12 2>/dev/null; then
+    echo "WARN: CERTIFICATE_P12_BASE64 inválido (no es base64)."
+    return 1
+  fi
+  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
+  security import dist.p12 -k "$(keychain get-default | awk 'END{print $NF}')" -P "$P12_PASSWORD" -T /usr/bin/codesign
+}
+
 # Inicializar llavero efímero (usar CLI oficial de Codemagic)
 keychain initialize
-KEYCHAIN_PATH="$(keychain get-default | tail -n1 | awk '{print $NF}')"
+KEYCHAIN_PATH="$(keychain get-default | awk 'END{print $NF}')"
 echo "Default keychain: $KEYCHAIN_PATH"
 
-# 1) Ruta MANUAL: si el usuario aporta un P12 en base64, importarlo con 'security import'
-if [ -n "${CERTIFICATE_P12_BASE64:-}" ]; then
-  echo "Importando P12 aportado…"
-  echo "$CERTIFICATE_P12_BASE64" | base64 --decode > dist.p12
-  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
-  security import dist.p12 -k "$KEYCHAIN_PATH" -P "$P12_PASSWORD" -T /usr/bin/codesign
-fi
+# Importación manual opcional
+import_p12_from_env || true
 
-# 2) Si aún no hay identidades, usar fetch-signing-files (auto)
-HAS_IDS="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -cE 'Apple (Distribution|Development)' || true)"
-if [ "${HAS_IDS:-0}" -eq 0 ]; then
+# Comprobar identidades de firma
+IDS=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -cE 'Apple (Distribution|Development)' || true)
+if [ "${IDS:-0}" -eq 0 ]; then
   echo "Sin identidades válidas; obteniendo firma desde App Store Connect…"
-  : "${APP_STORE_CONNECT_ISSUER_ID:?}"; : "${APP_STORE_CONNECT_KEY_IDENTIFIER:?}"; : "${APP_STORE_CONNECT_PRIVATE_KEY:?}"
+  : "${APP_STORE_CONNECT_ISSUER_ID:?}"
+  : "${APP_STORE_CONNECT_KEY_IDENTIFIER:?}"
+  : "${APP_STORE_CONNECT_PRIVATE_KEY:?}"
   app-store-connect fetch-signing-files "$BUNDLE_ID" \
     --type IOS_APP_STORE \
     --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
     --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
     --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
     --create
-  # Importar lo que descargó fetch-signing-files
   keychain add-certificates || true
 fi
 
@@ -45,6 +53,6 @@ security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
 echo "Perfiles disponibles:"
 ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
 
-mkdir -p artifacts
-cp "$LOG_FILE" artifacts/ || true
+mkdir -p "$ROOT_DIR/artifacts"
+cp "$LOG_FILE" "$ROOT_DIR/artifacts/" || true
 echo "Setup signing DONE"


### PR DESCRIPTION
## Summary
- validate P12 input and fall back to automatic App Store Connect signing if missing or invalid
- ensure build and signing logs are stored in artifacts

## Testing
- `bash -n setup-signing.sh build-ipa.sh`


------
https://chatgpt.com/codex/tasks/task_b_689cf1a0d3648327bedb3a93ca79cbeb