### PR TITLE
feat: streamline Codemagic signing and build scripts

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -5,10 +5,9 @@ LOG_FILE="$ROOT_DIR/codemagic_build_ipa.log"
 : > "$LOG_FILE"; exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "== Build IPA =="
-# Aplica perfiles al proyecto (usa el default keychain fijado por 'keychain initialize')
 xcode-project use-profiles
 flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 
-mkdir -p "$ROOT_DIR/artifacts"
-cp "$LOG_FILE" "$ROOT_DIR/artifacts/" || true
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
 echo "Build IPA DONE"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -8,15 +8,9 @@ workflows:
       vars:
         BUNDLE_ID: com.example.sansebassms
         APPLE_TEAM_ID: 7QWJ8R3ZB5
-        CERTIFICATE_P12_BASE64: $CERTIFICATE_P12_BASE64
-        P12_PASSWORD: $P12_PASSWORD
       groups:
         - app_store_connect
     scripts:
-      - name: Pre-build (deps, pods, firma, logging)
-        script: |
-          chmod +x pre-build.sh
-          ./pre-build.sh
       - name: Setup signing
         script: |
           chmod +x setup-signing.sh

--- a/setup-signing.sh
+++ b/setup-signing.sh
@@ -4,48 +4,38 @@ ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 LOG_FILE="$ROOT_DIR/codemagic_setup_signing.log"
 : > "$LOG_FILE"; exec > >(tee -a "$LOG_FILE") 2>&1
 
-echo "== Setup signing =="
+echo "== Setup signing (auto) =="
 
-# Vars mínimas
-require(){ local n="$1"; [ -n "${!n:-}" ] || { echo "ERROR: falta $n"; exit 2; }; }
-require APPLE_TEAM_ID
-require BUNDLE_ID
+need(){ [ -n "${!1:-}" ] || { echo "ERROR: falta $1"; exit 2; }; }
+need APP_STORE_CONNECT_ISSUER_ID
+need APP_STORE_CONNECT_KEY_IDENTIFIER
+need APP_STORE_CONNECT_PRIVATE_KEY     # .p8 (EC)
+need APPLE_CERTIFICATE_PRIVATE_KEY     # RSA 2048 PEM sin passphrase
+need APPLE_TEAM_ID
+need BUNDLE_ID
 
-import_p12_from_env() {
-  [ -n "${CERTIFICATE_P12_BASE64:-}" ] || return 1
-  echo "Importando P12 aportado…"
-  # Guardado y sanitizado mínimo (ignora basura si hubiera)
-  if ! printf "%s" "$CERTIFICATE_P12_BASE64" | base64 --decode --ignore-garbage > dist.p12 2>/dev/null; then
-    echo "WARN: CERTIFICATE_P12_BASE64 inválido (no es base64)."
-    return 1
-  fi
-  : "${P12_PASSWORD:?Missing P12_PASSWORD}"
-  security import dist.p12 -k "$(keychain get-default | awk 'END{print $NF}')" -P "$P12_PASSWORD" -T /usr/bin/codesign
-}
+# No usar P12 manual en este flujo
+unset CERTIFICATE_P12_BASE64 P12_PASSWORD || true
 
-# Inicializar llavero efímero (usar CLI oficial de Codemagic)
+# Llavero por defecto de Codemagic
 keychain initialize
 KEYCHAIN_PATH="$(keychain get-default | awk 'END{print $NF}')"
 echo "Default keychain: $KEYCHAIN_PATH"
 
-# Importación manual opcional
-import_p12_from_env || true
+# Descarga/creación de cert + perfiles (usa la RSA como certificado-key)
+CERT_FLAG="--certificate-key"
+app-store-connect fetch-signing-files --help | grep -q -- "--certificate-key" || CERT_FLAG="--cert-private-key"
 
-# Comprobar identidades de firma
-IDS=$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" | grep -cE 'Apple (Distribution|Development)' || true)
-if [ "${IDS:-0}" -eq 0 ]; then
-  echo "Sin identidades válidas; obteniendo firma desde App Store Connect…"
-  : "${APP_STORE_CONNECT_ISSUER_ID:?}"
-  : "${APP_STORE_CONNECT_KEY_IDENTIFIER:?}"
-  : "${APP_STORE_CONNECT_PRIVATE_KEY:?}"
-  app-store-connect fetch-signing-files "$BUNDLE_ID" \
-    --type IOS_APP_STORE \
-    --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
-    --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-    --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
-    --create
-  keychain add-certificates || true
-fi
+app-store-connect fetch-signing-files "$BUNDLE_ID" \
+  --type IOS_APP_STORE \
+  --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
+  --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+  --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
+  $CERT_FLAG "$APPLE_CERTIFICATE_PRIVATE_KEY" \
+  --create
+
+# Importar lo descargado al keychain por defecto
+keychain add-certificates || true
 
 echo "Identidades de firma:"
 security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
@@ -53,6 +43,6 @@ security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
 echo "Perfiles disponibles:"
 ls -la ~/Library/MobileDevice/Provisioning\ Profiles/ || true
 
-mkdir -p "$ROOT_DIR/artifacts"
-cp "$LOG_FILE" "$ROOT_DIR/artifacts/" || true
+mkdir -p artifacts
+cp "$LOG_FILE" artifacts/ || true
 echo "Setup signing DONE"


### PR DESCRIPTION
## Summary
- replace setup-signing.sh with auto signing using Codemagic CLI and RSA key
- simplify build-ipa.sh logging and invocation
- update codemagic.yaml to use new scripts and vars

## Testing
- `bash -n setup-signing.sh build-ipa.sh`
- `yamllint codemagic.yaml` *(fails: command not found)*
- `pip install yamllint` *(fails: Could not find a version that satisfies the requirement yamllint)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689cf955e128832783d752bd12ab0d5e