### PR TITLE
fix: initialize notifications on iOS

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,15 +23,24 @@ void main() async {
 
 Future<void> _initNotifications() async {
   const androidSettings = AndroidInitializationSettings('@mipmap/ic_launcher');
-  const initSettings = InitializationSettings(android: androidSettings);
-  await flutterLocalNotificationsPlugin.initialize(
-    initSettings,
-    onDidReceiveNotificationResponse: (response) {
-      if (response.payload == "abrir_usuario_screen") {
-        navigatorKey.currentState?.pushNamed("/usuario");
-      }
-    },
+  const iosSettings = DarwinInitializationSettings();
+  const initSettings = InitializationSettings(
+    android: androidSettings,
+    iOS: iosSettings,
   );
+  try {
+    await flutterLocalNotificationsPlugin.initialize(
+      initSettings,
+      onDidReceiveNotificationResponse: (response) {
+        if (response.payload == "abrir_usuario_screen") {
+          navigatorKey.currentState?.pushNamed("/usuario");
+        }
+      },
+    );
+  } catch (e) {
+    // Avoid blocking app startup if notifications fail to initialize
+    debugPrint('Notification init failed: $e');
+  }
 }
 
 class SansebasSmsApp extends StatelessWidget {


### PR DESCRIPTION
## Summary
- initialize local notifications with Darwin settings and guard failure so app launches on iOS

## Testing
- `dart format lib/main.dart` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_689f002756fc83278c9b9e3f3ca9f5ab