### PR TITLE
Fix App Store Connect API key configuration

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -44,8 +44,8 @@ workflows:
 
     publishing:
       app_store_connect:
-        api_key: $APP_STORE_CONNECT_KEY_IDENTIFIER
-        issuer_id: $APP_STORE_CONNECT_ISSUER_ID
-        key: $APP_STORE_CONNECT_PRIVATE_KEY
+        api_key: $APP_STORE_CONNECT_PRIVATE_KEY      # contenido del archivo .p8
+        key_id: $APP_STORE_CONNECT_KEY_IDENTIFIER    # Key ID (ej: 43Z3JZ75L6)
+        issuer_id: $APP_STORE_CONNECT_ISSUER_ID      # Issuer ID (UUID)
         submit_to_testflight: true
 


### PR DESCRIPTION
## Summary
- Correct App Store Connect authentication fields in codemagic workflow

## Testing
- `ruby -e "require 'yaml'; YAML.load_file('codemagic.yaml'); puts 'YAML validation passed'"`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c49964f083278822d4fb4816a343