### PR TITLE
Add iOS build artifacts to Codemagic workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,6 +16,11 @@ workflows:
       - name: Post-build
         script: ./post-build.sh
 
+    artifacts:
+      - build/ios/ipa/*.ipa
+      - build/ios/ipa/*.dSYM.zip
+      - build/ios/ipa/*.app.dSYM.zip
+
     publishing:
       app_store_connect:
         api_key: $APP_STORE_CONNECT_PRIVATE_KEY      # contenido del archivo .p8


### PR DESCRIPTION
## Summary
- expose IPA and dSYM archives as downloadable artifacts

## Testing
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1cf229f008327b5f92f32d8363f64