### PR TITLE
Include Firebase plist via CI prebuild

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,8 +12,9 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
-		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
-		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+                97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                A6E94C84B4D747CDA46FDF5B /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = BBA1348343584D40AE186F48 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -54,7 +55,8 @@
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                BBA1348343584D40AE186F48 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = GoogleService-Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,12 +114,13 @@
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
 				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
-				97C147021CF9000F007C117D /* Info.plist */,
-				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
-				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
-				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
-				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
-			);
+                                97C147021CF9000F007C117D /* Info.plist */,
+                                BBA1348343584D40AE186F48 /* GoogleService-Info.plist */,
+                                1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
+                                1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
+                                74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+                                74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
+                        );
 			path = Runner;
 			sourceTree = "<group>";
 		};
@@ -208,17 +211,18 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		97C146EC1CF9000F007C117D /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
-				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
+                97C146EC1CF9000F007C117D /* Resources */ = {
+                        isa = PBXResourcesBuildPhase;
+                        buildActionMask = 2147483647;
+                        files = (
+                                97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
+                                3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
+                                A6E94C84B4D747CDA46FDF5B /* GoogleService-Info.plist in Resources */,
+                                97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
+                                97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+                        );
+                        runOnlyForDeploymentPostprocessing = 0;
+                };
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/pre-build.sh
+++ b/pre-build.sh
@@ -33,7 +33,8 @@ PLIST_PATH="ios/Runner/GoogleService-Info.plist"
 if [[ -n "${GOOGLE_SERVICE_INFO_PLIST_B64:-}" ]]; then
   echo "Processing GOOGLE_SERVICE_INFO_PLIST_B64..."
   mkdir -p ios/Runner
-  if printf '%s' "$GOOGLE_SERVICE_INFO_PLIST_B64" | base64 --decode > "$PLIST_PATH.tmp" 2>/dev/null; then
+  if printf '%s' "$GOOGLE_SERVICE_INFO_PLIST_B64" | base64 --decode > "$PLIST_PATH.tmp" 2>/dev/null \
+    || printf '%s' "$GOOGLE_SERVICE_INFO_PLIST_B64" | base64 -d > "$PLIST_PATH.tmp" 2>/dev/null; then
     mv "$PLIST_PATH.tmp" "$PLIST_PATH"
     echo "Decoded Base64 plist"
   elif grep -q '<plist' <<<"$GOOGLE_SERVICE_INFO_PLIST_B64"; then


### PR DESCRIPTION
## Summary
- decode `GOOGLE_SERVICE_INFO_PLIST_B64` with cross-platform base64
- add placeholder GoogleService-Info.plist and reference it in Xcode project so Firebase config is bundled

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1e78645d883279cc290daa8525e83