### PR TITLE
Fix VAR length shell syntax in codemagic workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -20,7 +20,7 @@ workflows:
           VAR="${GOOGLE_SERVICE_INFO_PLIST_B64:-}"
           {
             echo "== PRE-BUILD PLIST =="
-            echo "VAR length: ${#VAR:-0}"
+            echo "VAR length: ${#VAR}"
             mkdir -p ios/Runner
             if [[ -z "$VAR" ]]; then
               echo "FATAL: GOOGLE_SERVICE_INFO_PLIST_B64 is empty"; exit 1


### PR DESCRIPTION
## Summary
- fix bad bash substitution in codemagic pre-build script by using `${#VAR}`

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a1f55574bc8327afa7cf0501256875