### PR TITLE
fix: correct plist decoding line

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -26,7 +26,7 @@ workflows:
               echo "FATAL: GOOGLE_SERVICE_INFO_PLIST_B64 is empty"; exit 1
             fi
             # decode base64 (GNU/BSD) con normalización CRLF; si falla y parece XML, escribir crudo
-            if (printf '%s' "$VAR" | tr -d '\r' | base64 --decode > "$PLIST_PATH" 2>/dev/null) || \\
+            if (printf '%s' "$VAR" | tr -d '\r' | base64 --decode > "$PLIST_PATH" 2>/dev/null) || \
                (printf '%s' "$VAR" | tr -d '\r' | base64 -D         > "$PLIST_PATH" 2>/dev/null); then
               echo "Decoded via base64"
             else


### PR DESCRIPTION
## Summary
- fix codemagic plist script by removing stray backslash in base64 decode check

## Testing
- `sudo apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fa10be608327a111e4c08d482cea