### PR TITLE
Run pre-build before iOS IPA build

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -5,6 +5,8 @@ LOG_FILE="$ROOT_DIR/codemagic_build_ipa.log"
 : > "$LOG_FILE"; exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "== Build IPA =="
+# Ensure dependencies and iOS workspace are prepared
+"$ROOT_DIR/pre-build.sh"
 xcode-project use-profiles
 flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 


### PR DESCRIPTION
## Summary
- ensure iOS workspace is prepared by running pre-build script before building IPA

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a1fe66323c8327a883ffdaf8cbe546