### PR TITLE
Fix codemagic artifact patterns

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -65,9 +65,9 @@ workflows:
       - build/ios/ipa/*.ipa
       - ios/Podfile.lock
       - ios/Runner.xcworkspace/**
-      - flutter_*.log
-      - **/xcpretty*.log
-      - **/*.xcresult
+      - "flutter_*.log"
+      - "**/xcpretty*.log"
+      - "**/*.xcresult"
 
     publishing:
       app_store_connect:


### PR DESCRIPTION
## Summary
- quote wildcard artifact patterns to avoid YAML alias parsing errors

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a2046527308327abc51d40cbadde65