### PR TITLE
Include IPA artifact in build output

### DIFF
--- a/build-ipa.sh
+++ b/build-ipa.sh
@@ -11,5 +11,6 @@ xcode-project use-profiles
 flutter build ipa --release --export-options-plist /Users/builder/export_options.plist
 
 mkdir -p artifacts
+cp build/ios/ipa/*.ipa artifacts/ || true
 cp "$LOG_FILE" artifacts/ || true
 echo "Build IPA DONE"


### PR DESCRIPTION
## Summary
- copy compiled `.ipa` into `artifacts`

## Testing
- `flutter test` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a20eb7052483278554d6890fcc50b6