### PR TITLE
Fix missing build_logs in Codemagic prebuild script

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -8,8 +8,8 @@ workflows:
       - name: Generar GoogleService-Info.plist
         script: |
           set -euo pipefail
-          echo "=== INICIO: GoogleService-Info.plist ===" | tee -a build_logs/prebuild.log
           mkdir -p build_logs
+          echo "=== INICIO: GoogleService-Info.plist ===" | tee -a build_logs/prebuild.log
           mkdir -p ios/Runner
           VAR="${GOOGLE_SERVICE_INFO_PLIST:-}"
           if [[ -z "${VAR}" ]]; then


### PR DESCRIPTION
## Summary
- ensure build_logs directory exists before writing prebuild log in Codemagic config

## Testing
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_b_68a215827f9c83278da36020dcd4d804