### PR TITLE
Secure iOS build and update Crashlytics

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -5,26 +5,10 @@ workflows:
         - app_store_connect
       xcode: latest
     scripts:
-      - name: Generar GoogleService-Info.plist
+      - name: Generar GoogleService-Info.plist (seguro)
         script: |
           set -euo pipefail
-          mkdir -p build_logs
-          echo "=== INICIO: GoogleService-Info.plist ===" | tee -a build_logs/prebuild.log
-          mkdir -p ios/Runner
-          VAR="${GOOGLE_SERVICE_INFO_PLIST:-}"
-          if [[ -z "${VAR}" ]]; then
-            echo "GOOGLE_SERVICE_INFO_PLIST vacío" | tee -a build_logs/prebuild.log
-            exit 1
-          fi
-          if [[ "${VAR}" =~ ^\<\?xml ]]; then
-            echo "${VAR}" > ios/Runner/GoogleService-Info.plist
-            echo "Es XML en claro" | tee -a build_logs/prebuild.log
-          else
-            echo "${VAR}" | base64 --decode > ios/Runner/GoogleService-Info.plist
-            echo "Decodificado desde base64" | tee -a build_logs/prebuild.log
-          fi
-          ls -l ios/Runner/GoogleService-Info.plist | tee -a build_logs/prebuild.log
-          head -n 6 ios/Runner/GoogleService-Info.plist | tee -a build_logs/prebuild.log
+          bash tool/prebuild_plist.sh
 
       - name: Instalar dependencias y CocoaPods
         script: |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   firebase_auth: ^6.0.1
   cloud_firestore: ^6.0.0
   firebase_messaging: ^16.0.0
-  firebase_crashlytics: ^4.0.0
+  firebase_crashlytics: ^5.0.0
 
   sqflite: ^2.3.0
   path: ^1.9.0

--- a/tool/prebuild_plist.sh
+++ b/tool/prebuild_plist.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_info() {
+  printf '%s\n' "$1"
+}
+
+plist_path="ios/Runner/GoogleService-Info.plist"
+
+# Ensure the environment variable is set and non-empty
+if [[ -z "${GOOGLE_SERVICE_INFO_PLIST:-}" ]]; then
+  log_info "GOOGLE_SERVICE_INFO_PLIST is empty"
+  exit 1
+fi
+
+log_info "PLIST length: ${#GOOGLE_SERVICE_INFO_PLIST}"
+
+value="${GOOGLE_SERVICE_INFO_PLIST}"
+mkdir -p "$(dirname "$plist_path")"
+
+# Detect base64: only base64 chars and length multiple of 4
+if printf '%s' "$value" | tr -d '\n\r' | grep -Eq '^[A-Za-z0-9+/=]+$' && [ $(( ${#value} % 4 )) -eq 0 ]; then
+  printf '%s' "$value" | base64 --decode > "$plist_path"
+else
+  printf '%s' "$value" > "$plist_path"
+fi
+
+chmod 0644 "$plist_path"
+
+if ! plutil -lint "$plist_path" >/dev/null 2>&1; then
+  log_info "plutil validation failed for $plist_path"
+  exit 1
+fi
+
+file_size=$(wc -c < "$plist_path" | tr -d ' ')
+checksum=$(shasum -a 256 "$plist_path" | awk '{print $1}')
+
+log_info "PLIST file size: ${file_size} bytes"
+log_info "PLIST sha256: ${checksum}"
+log_info "PLIST path: $plist_path"


### PR DESCRIPTION
## Summary
- add secure prebuild script to handle GoogleService-Info.plist without exposing secrets
- call new prebuild script from Codemagic workflow
- update firebase_crashlytics to ^5.0.0

## Testing
- `GOOGLE_SERVICE_INFO_PLIST="$encoded" bash tool/prebuild_plist.sh` *(fails: plutil validation failed for ios/Runner/GoogleService-Info.plist)*
- `flutter pub upgrade` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_b_68a21d481e248327a9059f3c3f6471e9