### PR TITLE
ci: build ios ipa without codesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ to provide the `GoogleService-Info.plist` contents during build time.
   ```
 
 - Paste the variable content **without quotes** and **without extra spaces**.
+
+## CI
+
+El build usa `--no-codesign`; Codemagic firma en Publish.

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -13,23 +13,31 @@ workflows:
       - name: Instalar dependencias y CocoaPods
         script: |
           set -euo pipefail
-          mkdir -p build_logs
-          echo "== POD INSTALL ==" | tee -a build_logs/build.log
-          flutter pub get 2>&1 | tee -a build_logs/build.log
+          echo "== POD INSTALL ==" | tee -a build.log
+          flutter pub get 2>&1 | tee -a build.log
           cd ios
-          pod install 2>&1 | tee -a ../build_logs/build.log
+          pod install --repo-update 2>&1 | tee -a ../build.log
           cd ..
 
       - name: Compilar IPA release
         script: |
           set -euo pipefail
-          mkdir -p build_logs
-          echo "== FLUTTER BUILD ==" | tee -a build_logs/build.log
-          flutter build ipa --release --build-number=$BUILD_NUMBER 2>&1 | tee -a build_logs/build.log
+          echo "== FLUTTER BUILD ==" | tee -a build.log
+          flutter clean 2>&1 | tee -a build.log
+          flutter pub get 2>&1 | tee -a build.log
+          # Runner.xcworkspace is used automatically; Codemagic signs on export/publish
+          flutter build ipa --release --no-codesign --build-number=${BUILD_NUMBER:-1} 2>&1 | tee -a build.log
+
+      - name: Empaquetar logs
+        script: |
+          set -e
+          zip -r build.log.zip build || true
 
     artifacts:
       - build/ios/ipa/*.ipa
-      - build_logs/**
+      - build/ios/archive/*.xcarchive
+      - build.log
+      - build.log.zip
 
     publishing:
       app_store_connect:

--- a/ios/Flutter/Debug.xcconfig
+++ b/ios/Flutter/Debug.xcconfig
@@ -2,3 +2,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 // Flutter-generated build settings (keep this include last).
 #include "Generated.xcconfig"
+CODE_SIGNING_ALLOWED = NO
+CODE_SIGNING_REQUIRED = NO

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -3,3 +3,5 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 // Flutter-generated build settings (keep this include last).
 #include "Generated.xcconfig"
+CODE_SIGNING_ALLOWED = NO
+CODE_SIGNING_REQUIRED = NO


### PR DESCRIPTION
## Summary
- build flutter ipa without codesign so codemagic signs during publish
- disable xcode codesigning during flutter build
- document no-codesign build in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a22287339483279168aa808b252b22