### PR TITLE
feat: handle missing google plist env

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -38,6 +38,7 @@ workflows:
       - build/ios/archive/*.xcarchive
       - build.log
       - build.log.zip
+      - prebuild_plist.log
 
     publishing:
       app_store_connect:


### PR DESCRIPTION
## Summary
- add detailed logging for GoogleService-Info.plist generation
- export prebuild log as build artifact

## Testing
- `bash tool/prebuild_plist.sh` (with GOOGLE_SERVICE_INFO_PLIST unset)
- `bash tool/prebuild_plist.sh` (with GOOGLE_SERVICE_INFO_PLIST base64)
- `bash -n tool/prebuild_plist.sh`
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2277c5f4c8327a6d5e3742da83915