### PR TITLE
Initialize Firebase for iOS

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Flutter
 import UIKit
+import FirebaseCore
 
 @main
 @objc class AppDelegate: FlutterAppDelegate {
@@ -8,6 +9,7 @@ import UIKit
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     NSLog("AppDelegate didFinishLaunchingWithOptions")
+    FirebaseApp.configure()
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }


### PR DESCRIPTION
## Summary
- Ensure iOS app initializes Firebase on launch by configuring `FirebaseApp` in `AppDelegate`.
- Confirm `GoogleService-Info.plist` is part of the Runner target so Firebase resources bundle correctly.

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_b_68a230aba6188327b9a439ef688d4aea