### PR TITLE
Ensure GoogleService-Info is included before code signing

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -32,34 +32,6 @@ workflows:
 
           # Validar que el plist exista
           test -f ios/Runner/GoogleService-Info.plist || { echo "Plist no encontrado"; exit 1; }
-      - name: Copy GoogleService-Info.plist into app
-        script: |
-          # === Crear GoogleService-Info.plist desde variable Base64 ===
-          python3 - <<'PY'
-          import os, base64, pathlib, sys
-          b64 = os.environ.get("GOOGLE_SERVICE_INFO_PLIST_B64", "")
-          if not b64:
-              print("ERROR: Falta la variable GOOGLE_SERVICE_INFO_PLIST_B64", file=sys.stderr)
-              sys.exit(1)
-          path = pathlib.Path("ios/Runner/GoogleService-Info.plist")
-          path.parent.mkdir(parents=True, exist_ok=True)
-          path.write_bytes(base64.b64decode(b64))
-          print(f"✅ Escrito {path} ({path.stat().st_size} bytes)")
-          PY
-
-          # Verificar que el plist existe
-          test -f ios/Runner/GoogleService-Info.plist || { echo "❌ Plist no creado"; exit 1; }
-
-          # === Copiarlo dentro del .app resultante ===
-          APP_PATH=$(find build/ -type d -name "*.xcarchive" -print -quit)/Products/Applications
-          DEST_APP=$(find "$APP_PATH" -maxdepth 1 -type d -name "*.app" -print -quit)
-
-          if [ -n "$DEST_APP" ] && [ -f ios/Runner/GoogleService-Info.plist ]; then
-            cp ios/Runner/GoogleService-Info.plist "$DEST_APP/GoogleService-Info.plist"
-            echo "✅ Copiado en bundle: $DEST_APP/GoogleService-Info.plist"
-          else
-            echo "⚠️ No se pudo copiar el plist al .app (quizá aún no está construido)"
-          fi
       - name: Build IPA
         script: |
           chmod +x build-ipa.sh

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -12,9 +12,10 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
-		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
-		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-/* End PBXBuildFile section */
+                97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
+                97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                D1A2B3C51D5E6F7080910113 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = D1A2B3C41D5E6F7080910112 /* GoogleService-Info.plist */; };
+        /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		331C8085294A63A400263BE5 /* PBXContainerItemProxy */ = {
@@ -54,7 +55,8 @@
 		97C146FB1CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+                D1A2B3C41D5E6F7080910112 /* GoogleService-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = GoogleService-Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -111,10 +113,11 @@
 			children = (
 				97C146FA1CF9000F007C117D /* Main.storyboard */,
 				97C146FD1CF9000F007C117D /* Assets.xcassets */,
-				97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
-				97C147021CF9000F007C117D /* Info.plist */,
-				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
-				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
+                97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */,
+                97C147021CF9000F007C117D /* Info.plist */,
+                D1A2B3C41D5E6F7080910112 /* GoogleService-Info.plist */,
+                1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
+                1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
@@ -214,9 +217,10 @@
 			files = (
 				97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */,
 				3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */,
-				97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
-				97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
-			);
+                97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */,
+                97C146FC1CF9000F007C117D /* Main.storyboard in Resources */,
+                D1A2B3C51D5E6F7080910113 /* GoogleService-Info.plist in Resources */,
+        );
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */

--- a/ios/Runner/GoogleService-Info.plist
+++ b/ios/Runner/GoogleService-Info.plist
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- add placeholder GoogleService-Info.plist and reference it in Xcode project
- simplify Codemagic workflow by removing redundant plist copy step

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2c8b7d24883279b32e38e292ff83d