### PR TITLE
fix: update bundle ID to com.example.sansebassms

### DIFF
--- a/macos/Runner/Configs/AppInfo.xcconfig
+++ b/macos/Runner/Configs/AppInfo.xcconfig
@@ -11,4 +11,4 @@ PRODUCT_NAME = sansebassms
 PRODUCT_BUNDLE_IDENTIFIER = com.example.sansebassms
 
 // The copyright displayed in application information
-PRODUCT_COPYRIGHT = Copyright © 2025 com.example. All rights reserved.
+PRODUCT_COPYRIGHT = Copyright © 2025 com.example.sansebassms. All rights reserved.

--- a/windows/runner/Runner.rc
+++ b/windows/runner/Runner.rc
@@ -89,11 +89,11 @@ BEGIN
     BEGIN
         BLOCK "040904e4"
         BEGIN
-            VALUE "CompanyName", "com.example" "\0"
+            VALUE "CompanyName", "com.example.sansebassms" "\0"
             VALUE "FileDescription", "sansebassms" "\0"
             VALUE "FileVersion", VERSION_AS_STRING "\0"
             VALUE "InternalName", "sansebassms" "\0"
-            VALUE "LegalCopyright", "Copyright (C) 2025 com.example. All rights reserved." "\0"
+            VALUE "LegalCopyright", "Copyright (C) 2025 com.example.sansebassms. All rights reserved." "\0"
             VALUE "OriginalFilename", "sansebassms.exe" "\0"
             VALUE "ProductName", "sansebassms" "\0"
             VALUE "ProductVersion", VERSION_AS_STRING "\0"


### PR DESCRIPTION
## Summary
- replace default `com.example` references with `com.example.sansebassms` in macOS and Windows configs

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a2d1b2cef883278f6faa20c4d41b2d