### PR TITLE
Register APNs token with Firebase Messaging

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,13 +1,48 @@
-import Flutter
 import UIKit
+import Flutter
+import Firebase
+import UserNotifications
 
-@main
-@objc class AppDelegate: FlutterAppDelegate {
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
+
   override func application(
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
+    // Firebase
+    FirebaseApp.configure()
+
+    // Notificaciones iOS
+    UNUserNotificationCenter.current().delegate = self
+    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { _, _ in }
+    application.registerForRemoteNotifications()
+
+    // FCM
+    Messaging.messaging().delegate = self
+
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
+
+  // APNs -> pásalo a Firebase
+  override func application(_ application: UIApplication,
+                            didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+    Messaging.messaging().apnsToken = deviceToken
+    super.application(application, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+  }
+
+  // (Opcional) Log del FCM token cuando esté listo
+  func messaging(_ messaging: Messaging, didReceiveRegistrationToken fcmToken: String?) {
+    NSLog("FCM token: \(fcmToken ?? "nil")")
+  }
+
+  // Mostrar notificaciones en foreground (iOS 10+)
+  @available(iOS 10.0, *)
+  public func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                     willPresent notification: UNNotification,
+                                     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+    completionHandler([.badge, .banner, .sound])
+  }
 }
+


### PR DESCRIPTION
## Summary
- configure Firebase and iOS notification delegates in AppDelegate
- forward APNs device token to Firebase and log FCM token
- enable badge, banner, and sound for foreground notifications

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2ec84ae8083279e5358ef27714f38