### PR TITLE
fix: update iOS notification delegate

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -4,7 +4,7 @@ import Firebase
 import UserNotifications
 
 @UIApplicationMain
-@objc class AppDelegate: FlutterAppDelegate, UNUserNotificationCenterDelegate, MessagingDelegate {
+@objc class AppDelegate: FlutterAppDelegate, MessagingDelegate {
 
   override func application(
     _ application: UIApplication,
@@ -39,9 +39,9 @@ import UserNotifications
 
   // Mostrar notificaciones en foreground (iOS 10+)
   @available(iOS 10.0, *)
-  public func userNotificationCenter(_ center: UNUserNotificationCenter,
-                                     willPresent notification: UNNotification,
-                                     withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
+  override func userNotificationCenter(_ center: UNUserNotificationCenter,
+                                       willPresent notification: UNNotification,
+                                       withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void) {
     completionHandler([.badge, .banner, .sound])
   }
 }


### PR DESCRIPTION
## Summary
- remove redundant UNUserNotificationCenterDelegate conformance
- override userNotificationCenter in AppDelegate

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a2f1f09ae48327b4d9e571f7c61c9e