### PR TITLE
fix(ios): correct entitlements for push notifications

### DIFF
--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -4,10 +4,5 @@
 <dict>
   <key>aps-environment</key>
   <string>production</string>
-  <key>UIBackgroundModes</key>
-  <array>
-    <string>remote-notification</string>
-  </array>
 </dict>
 </plist>
-


### PR DESCRIPTION
## Summary
- remove `UIBackgroundModes` from Runner.entitlements and set `aps-environment` to `production`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a60aeecce08327b280bcc3530b9813