### PR TITLE
feat: update patch for iOS identifiers

### DIFF
--- a/ios/patch-ios-identifiers.sh
+++ b/ios/patch-ios-identifiers.sh
@@ -1,28 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
 PLIST_RUNNER="ios/Runner/Info.plist"
 PLIST_GOOGLE="ios/Runner/GoogleService-Info.plist"
 
-# Verifica que existe el plist de Firebase (lo genera el job)
-test -f "$PLIST_GOOGLE"
+echo "== Patch iOS identifiers =="
 
-# Lee REVERSED_CLIENT_ID desde GoogleService-Info.plist
-REV=$(/usr/libexec/PlistBuddy -c 'Print :REVERSED_CLIENT_ID' "$PLIST_GOOGLE")
-if [[ -n "${REV:-}" ]]; then
-  # Asegura CFBundleURLTypes con el URL scheme correcto
-  /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST_RUNNER" 2>/dev/null || true
-  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST_RUNNER"
-  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST_RUNNER"
-  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST_RUNNER"
-  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string $REV" "$PLIST_RUNNER"
+# --- (Opcional) URL scheme desde REVERSED_CLIENT_ID si existe ---
+if [[ -s "$PLIST_GOOGLE" ]] && /usr/libexec/PlistBuddy -c 'Print :REVERSED_CLIENT_ID' "$PLIST_GOOGLE" >/dev/null 2>&1; then
+  REV=$(/usr/libexec/PlistBuddy -c 'Print :REVERSED_CLIENT_ID' "$PLIST_GOOGLE")
+  echo "Found REVERSED_CLIENT_ID: $REV"
+  /usr/libexec/PlistBuddy -c "Delete :CFBundleURLTypes" "$PLIST_RUNNER" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes array" "$PLIST_RUNNER" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0 dict" "$PLIST_RUNNER" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes array" "$PLIST_RUNNER" >/dev/null 2>&1 || true
+  /usr/libexec/PlistBuddy -c "Add :CFBundleURLTypes:0:CFBundleURLSchemes:0 string $REV" "$PLIST_RUNNER" >/dev/null 2>&1 || true
+  echo "✅ URL scheme aplicado"
+else
+  echo "ℹ️  REVERSED_CLIENT_ID no existe en GoogleService-Info.plist; se omite el patch de URL scheme"
 fi
 
-# Asegura Background Modes -> remote-notification en Info.plist (no en entitlements)
-if ! /usr/libexec/PlistBuddy -c "Print :UIBackgroundModes" "$PLIST_RUNNER" >/dev/null 2>&1; then
+# --- Background fetch para notificaciones remotas (clave de Info.plist, NO entitlement) ---
+/usr/libexec/PlistBuddy -c "Print :UIBackgroundModes" "$PLIST_RUNNER" >/dev/null 2>&1 || \
   /usr/libexec/PlistBuddy -c "Add :UIBackgroundModes array" "$PLIST_RUNNER"
-fi
-if ! /usr/libexec/PlistBuddy -c "Print :UIBackgroundModes" "$PLIST_RUNNER" | grep -q "remote-notification"; then
+/usr/libexec/PlistBuddy -c "Print :UIBackgroundModes" "$PLIST_RUNNER" | grep -q "remote-notification" || \
   /usr/libexec/PlistBuddy -c "Add :UIBackgroundModes:0 string remote-notification" "$PLIST_RUNNER"
-fi
-echo "Patched Info.plist (URL scheme & UIBackgroundModes)."
+
+echo "✅ Patch completo"
 


### PR DESCRIPTION
## Summary
- rewrite patch-ios-identifiers.sh to handle optional REVERSED_CLIENT_ID and remote notification background mode

## Testing
- `bash -n ios/patch-ios-identifiers.sh`
- `bash ios/patch-ios-identifiers.sh` *(fails: /usr/libexec/PlistBuddy: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_b_68a624e8ed64832791e2b500e02e9337