### PR TITLE
Add fallback App Store Connect upload step

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -40,6 +40,21 @@ workflows:
         script: |
           chmod +x build-ipa.sh
           ./build-ipa.sh
+      - name: Upload to App Store Connect (fallback)
+        script: |
+          set -euo pipefail
+          IPA_PATH="$(ls -1 build/ios/ipa/*.ipa | head -n 1)"
+          echo "IPA to upload: ${IPA_PATH}"
+          test -f "$IPA_PATH"
+          app-store-connect publish \
+            --path "$IPA_PATH" \
+            --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
+            --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
+            --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
+            --bundle-id "$BUNDLE_ID" \
+            --submit-to-testflight true \
+            --beta-group "Internal Testers" \
+            --verbose
     artifacts:
       - build/ios/ipa/*.ipa
       - codemagic_prebuild.log


### PR DESCRIPTION
## Summary
- upload fallback builds to App Store Connect via CLI in Codemagic config

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68a9d4ebfe9883279b0f404a2510a4a0