### PR TITLE
ci: fix ASC key check (replace whoami with list-bundle-ids)

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,10 +16,22 @@ workflows:
           set -euo pipefail
           ASC_KEY=/tmp/asc_api_key.p8
           printf '%s\n' "$APP_STORE_CONNECT_PRIVATE_KEY" > "$ASC_KEY"
-          app-store-connect whoami \
+
+          mkdir -p artifacts
+          echo "Validando API key de App Store Connect y acceso al bundle ${BUNDLE_ID} ..."
+          app-store-connect list-bundle-ids \
+            --identifier "$BUNDLE_ID" \
             --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-            --private-key "$ASC_KEY"
+            --private-key "$ASC_KEY" \
+            > artifacts/asc_check.json
+
+          echo "Salida guardada en artifacts/asc_check.json"
+          if grep -q "\"identifier\": \"${BUNDLE_ID}\"" artifacts/asc_check.json; then
+            echo "✅ API key válida y acceso al bundle confirmado."
+          else
+            echo "⚠️ API key válida, pero no se encontró el bundle o no tienes acceso."
+          fi
 
       - name: Setup signing
         script: |


### PR DESCRIPTION
## Summary
- validate App Store Connect API key by listing bundle IDs

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_b_68aa1e9b3d948327ae6256253c7bf8e5