### PR TITLE
ci(ios): fix grep pattern and sanitize PEM for ASC key check

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -16,18 +16,26 @@ workflows:
           set -euo pipefail
           mkdir -p artifacts
 
-          # Sanity: debe ser un PEM multilínea válido
-          if ! printf '%s\n' "$APP_STORE_CONNECT_PRIVATE_KEY" | grep -q '-----BEGIN PRIVATE KEY-----'; then
-            echo "❌ APP_STORE_CONNECT_PRIVATE_KEY no contiene un PEM válido (revisa que sea multilínea y con BEGIN/END)."
+          # Sanea posibles CRLF sin imprimir la clave
+          ASC_KEY_SANITIZED="$(printf '%s\n' "$APP_STORE_CONNECT_PRIVATE_KEY" | tr -d '\r')"
+
+          # Validación defensiva del PEM sin exponer contenido
+          if ! printf '%s\n' "$ASC_KEY_SANITIZED" | grep -q -- '-----BEGIN PRIVATE KEY-----'; then
+            echo "❌ APP_STORE_CONNECT_PRIVATE_KEY no contiene BEGIN"
+            exit 2
+          fi
+          if ! printf '%s\n' "$ASC_KEY_SANITIZED" | grep -q -- '-----END PRIVATE KEY-----'; then
+            echo "❌ APP_STORE_CONNECT_PRIVATE_KEY no contiene END"
             exit 2
           fi
 
+          # Comprobación contra App Store Connect
           echo "Validando API key de App Store Connect y acceso al bundle ${BUNDLE_ID} ..."
           app-store-connect list-bundle-ids \
             --identifier "$BUNDLE_ID" \
             --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
-            --private-key "$APP_STORE_CONNECT_PRIVATE_KEY" \
+            --private-key "$ASC_KEY_SANITIZED" \
             --json > artifacts/asc_check.json
 
           echo "Salida guardada en artifacts/asc_check.json"


### PR DESCRIPTION
## Summary
- sanitize CRLF and validate App Store Connect private key defensively

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68aa244faaa48327b4f66cc21fface6a