### PR TITLE
ci: fix ASC key check — use --bundle-id-identifier flag for list-bundle-ids

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -29,10 +29,10 @@ workflows:
             exit 2
           fi
 
-          # Comprobación contra App Store Connect
           echo "Validando API key de App Store Connect y acceso al bundle ${BUNDLE_ID} ..."
           app-store-connect list-bundle-ids \
-            --identifier "$BUNDLE_ID" \
+            --bundle-id-identifier "$BUNDLE_ID" \
+            --strict-match-identifier \
             --issuer-id "$APP_STORE_CONNECT_ISSUER_ID" \
             --key-id "$APP_STORE_CONNECT_KEY_IDENTIFIER" \
             --private-key "$ASC_KEY_SANITIZED" \


### PR DESCRIPTION
## Summary
- refine App Store Connect API key check script to use `--bundle-id-identifier` and `--strict-match-identifier` when listing bundle IDs

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_b_68aa259a95e483278fec732a243d5053