### PR TITLE
Read Android version from pubspec

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -15,6 +15,9 @@ val keystoreProps = Properties().apply {
     }
 }
 
+val flutterVersionCode = project.properties["flutter.versionCode"] as String? ?: "1"
+val flutterVersionName = project.properties["flutter.versionName"] as String? ?: "1.0"
+
 android {
     namespace = "com.sansebas.sansebassms"
     compileSdk = 35
@@ -34,8 +37,8 @@ android {
         applicationId = "com.sansebas.sansebassms"
         minSdk = 23
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = flutterVersionCode.toInt()
+        versionName = flutterVersionName
 
         // ✅ Habilitar multidex
         multiDexEnabled = true


### PR DESCRIPTION
## Summary
- Read `flutter.versionCode` and `flutter.versionName` from project properties
- Apply them in `defaultConfig` so Android build uses the pubspec version

## Testing
- ⚠️ `flutter test` (command not found)
- ⚠️ `./gradlew -q help` (No such file or directory)

------
https://chatgpt.com/codex/tasks/task_b_68c5a364c00083279c43cc0dd70b8fc2