### PR TITLE
Add personal area screen for day-off requests

### DIFF
--- a/lib/screens/areapersonal_screen.dart
+++ b/lib/screens/areapersonal_screen.dart
@@ -1,0 +1,130 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class AreaPersonalScreen extends StatefulWidget {
+  const AreaPersonalScreen({super.key});
+
+  @override
+  State<AreaPersonalScreen> createState() => _AreaPersonalScreenState();
+}
+
+class _AreaPersonalScreenState extends State<AreaPersonalScreen> {
+  bool _guardando = false;
+
+  Future<void> _solicitarDiaLibre() async {
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      _mostrarSnackBar('Debes iniciar sesión');
+      return;
+    }
+
+    final picked = await showDatePicker(
+      context: context,
+      locale: const Locale('es', 'ES'),
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 365)),
+      initialDate: DateTime.now(),
+    );
+
+    if (picked == null) {
+      return;
+    }
+
+    final selectedDate = DateTime(picked.year, picked.month, picked.day);
+    final formattedDate = DateFormat('yyyyMMdd').format(selectedDate);
+    final docId = '${user.uid}_$formattedDate';
+
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _guardando = true;
+    });
+
+    try {
+      await FirebaseFirestore.instance
+          .collection('Peticiones')
+          .doc(docId)
+          .set(
+        {
+          'uid': user.uid,
+          'Fecha': Timestamp.fromDate(selectedDate),
+          'Admitido': 'Pendiente',
+          'creadoEn': FieldValue.serverTimestamp(),
+        },
+        SetOptions(merge: true),
+      );
+
+      if (!mounted) return;
+      _mostrarSnackBar('Petición registrada para $formattedDate');
+    } catch (e) {
+      if (!mounted) return;
+      _mostrarSnackBar('Error al guardar la petición: ${e.toString()}');
+    } finally {
+      if (mounted) {
+        setState(() {
+          _guardando = false;
+        });
+      }
+    }
+  }
+
+  void _mostrarSnackBar(String mensaje) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text(mensaje)),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+
+    final tiles = <Widget>[
+      Card(
+        child: ListTile(
+          leading: const Icon(Icons.event_available),
+          title: const Text('Petición de días libres'),
+          subtitle: const Text('Selecciona un día para solicitarlo'),
+          trailing: _guardando
+              ? const SizedBox(
+                  height: 24,
+                  width: 24,
+                  child: CircularProgressIndicator(strokeWidth: 2),
+                )
+              : const Icon(Icons.chevron_right),
+          onTap: _guardando ? null : _solicitarDiaLibre,
+        ),
+      ),
+    ];
+
+    if (user == null) {
+      tiles.insert(
+        0,
+        Card(
+          child: ListTile(
+            leading: const Icon(Icons.lock_outline),
+            title: const Text('Debes iniciar sesión'),
+            subtitle:
+                const Text('Inicia sesión para registrar tus peticiones'),
+          ),
+        ),
+      );
+    }
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Área personal')),
+      body: Scrollbar(
+        child: ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemBuilder: (context, index) => tiles[index],
+          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          itemCount: tiles.length,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/usuario_screen.dart
+++ b/lib/screens/usuario_screen.dart
@@ -6,6 +6,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:permission_handler/permission_handler.dart';
 
+import 'areapersonal_screen.dart';
+
 class UsuarioScreen extends StatefulWidget {
   const UsuarioScreen({super.key});
 
@@ -186,6 +188,17 @@ class _UsuarioScreenState extends State<UsuarioScreen> {
             ],
           ),
         ),
+        floatingActionButton: FloatingActionButton.extended(
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const AreaPersonalScreen(),
+              ),
+            );
+          },
+          icon: const Icon(Icons.person),
+          label: const Text('Área personal'),
+        ),
       );
     }
 
@@ -269,6 +282,17 @@ class _UsuarioScreenState extends State<UsuarioScreen> {
             );
           },
         ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (_) => const AreaPersonalScreen(),
+            ),
+          );
+        },
+        icon: const Icon(Icons.person),
+        label: const Text('Área personal'),
       ),
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   firebase_auth: ^6.0.1
   cloud_firestore: ^6.0.0
   firebase_messaging: ^16.0.0
+  intl: ^0.18.1
 
 # Pod build fix for Xcode 16
 # Keeping firebase packages current ensures their podspecs do not include


### PR DESCRIPTION
## Summary
- add a floating action button in `UsuarioScreen` that opens the new personal area
- implement the `AreaPersonalScreen` with a leave-request tile that persists selections in Firestore
- include the `intl` dependency for formatting the request document id

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9ab23e93c8327af5d2ab34a0003c5