### PR TITLE
Add screen to review and cancel personal requests

### DIFF
--- a/lib/screens/areapersonal_screen.dart
+++ b/lib/screens/areapersonal_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'mis_peticiones_screen.dart';
 import 'report_mensajes_screen.dart';
 
 class AreaPersonalScreen extends StatefulWidget {
@@ -99,6 +100,22 @@ class _AreaPersonalScreenState extends State<AreaPersonalScreen> {
                 )
               : const Icon(Icons.chevron_right),
           onTap: _guardando ? null : _solicitarDiaLibre,
+        ),
+      ),
+      Card(
+        child: ListTile(
+          leading: const Icon(Icons.list_alt),
+          title: const Text('Mis peticiones'),
+          subtitle:
+              const Text('Consulta el estado de tus peticiones enviadas'),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => MisPeticionesScreen(),
+              ),
+            );
+          },
         ),
       ),
       Card(

--- a/lib/screens/mis_peticiones_screen.dart
+++ b/lib/screens/mis_peticiones_screen.dart
@@ -1,0 +1,181 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class MisPeticionesScreen extends StatelessWidget {
+  MisPeticionesScreen({super.key});
+
+  final ValueNotifier<Set<String>> _deleting =
+      ValueNotifier<Set<String>>(<String>{});
+
+  Future<void> _cancelPeticion(
+    BuildContext context,
+    DocumentSnapshot<Map<String, dynamic>> doc,
+  ) async {
+    final confirmacion = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Cancelar petición'),
+          content: const Text('¿Cancelar esta petición?'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('No'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Sí, cancelar'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (confirmacion != true) {
+      return;
+    }
+
+    final messenger = ScaffoldMessenger.of(context);
+
+    _deleting.value = {..._deleting.value, doc.id};
+
+    try {
+      await doc.reference.delete();
+      messenger.showSnackBar(
+        const SnackBar(content: Text('Petición cancelada correctamente.')),
+      );
+    } on FirebaseException catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('No se pudo cancelar: ${e.message ?? e.code}')),
+      );
+    } catch (e) {
+      messenger.showSnackBar(
+        SnackBar(content: Text('No se pudo cancelar: $e')),
+      );
+    } finally {
+      final updated = {..._deleting.value};
+      updated.remove(doc.id);
+      _deleting.value = updated;
+    }
+  }
+
+  String _formatFecha(dynamic value) {
+    DateTime? fecha;
+    if (value is Timestamp) {
+      fecha = value.toDate();
+    } else if (value is DateTime) {
+      fecha = value;
+    }
+
+    if (fecha == null) {
+      return 'Fecha no disponible';
+    }
+
+    return DateFormat('dd/MM/yyyy', 'es_ES').format(fecha);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+
+    if (user == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Mis peticiones')),
+        body: const Center(
+          child: Padding(
+            padding: EdgeInsets.all(24),
+            child: Text('Debes iniciar sesión para consultar tus peticiones.'),
+          ),
+        ),
+      );
+    }
+
+    final query = FirebaseFirestore.instance
+        .collection('Peticiones')
+        .where('uid', isEqualTo: user.uid)
+        .orderBy('Fecha', descending: true);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mis peticiones')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: query.snapshots(),
+        builder: (context, snapshot) {
+          if (snapshot.hasError) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text('Error al cargar las peticiones.'),
+              ),
+            );
+          }
+
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          final docs = snapshot.data?.docs ?? <QueryDocumentSnapshot<Map<String, dynamic>>>[];
+
+          if (docs.isEmpty) {
+            return const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text('Aún no has registrado peticiones.'),
+              ),
+            );
+          }
+
+          return Scrollbar(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(16),
+              itemCount: docs.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 12),
+              itemBuilder: (context, index) {
+                final doc = docs[index];
+                final data = doc.data();
+                final fechaTexto = _formatFecha(data['Fecha']);
+                final estado = (data['Admitido'] as String?) ?? 'Pendiente';
+                final isPendiente = estado == 'Pendiente';
+
+                return Card(
+                  child: ListTile(
+                    leading: const Icon(Icons.event_note),
+                    title: Text(fechaTexto),
+                    subtitle: Text('Estado: $estado'),
+                    trailing: isPendiente
+                        ? ValueListenableBuilder<Set<String>>(
+                            valueListenable: _deleting,
+                            builder: (context, deleting, _) {
+                              final isDeleting = deleting.contains(doc.id);
+                              if (isDeleting) {
+                                return const SizedBox(
+                                  height: 24,
+                                  width: 24,
+                                  child:
+                                      CircularProgressIndicator(strokeWidth: 2),
+                                );
+                              }
+
+                              return TextButton.icon(
+                                icon: const Icon(Icons.cancel),
+                                label: const Text('Cancelar'),
+                                style: TextButton.styleFrom(
+                                  foregroundColor:
+                                      Theme.of(context).colorScheme.error,
+                                ),
+                                onPressed: () => _cancelPeticion(context, doc),
+                              );
+                            },
+                          )
+                        : const Icon(Icons.lock),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new "Mis peticiones" entry in the área personal menu
- implement the mis peticiones screen that streams the user's petitions ordered by date
- allow cancelling pending petitions with confirmation dialog and feedback via snackbars

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9af5e21248327a52d6c63034bec7e