### PR TITLE
Update intl dependency for Flutter SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_auth: ^6.0.1
   cloud_firestore: ^6.0.0
   firebase_messaging: ^16.0.0
-  intl: ^0.18.0
+  intl: ^0.20.2
 
 # Pod build fix for Xcode 16
 # Keeping firebase packages current ensures their podspecs do not include


### PR DESCRIPTION
## Summary
- raise the intl dependency to ^0.20.2 so it matches the version required by flutter_localizations

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_b_68c9c3cc44d88327883422f5d338d557