### PR TITLE
Fix dialog theme configuration for Material 3

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -157,7 +157,7 @@ class SansebasSmsApp extends StatelessWidget {
       theme: ThemeData(
         colorSchemeSeed: Colors.green,
         useMaterial3: true,
-        dialogTheme: const DialogTheme(
+        dialogTheme: const DialogThemeData(
           surfaceTintColor: Colors.transparent,
         ),
       ),

--- a/lib/screens/areapersonal_screen.dart
+++ b/lib/screens/areapersonal_screen.dart
@@ -50,7 +50,7 @@ class _AreaPersonalScreenState extends State<AreaPersonalScreen> {
               onSurface: Colors.black,
               primary: scheme.primary,
             ),
-            dialogTheme: const DialogTheme(
+            dialogTheme: const DialogThemeData(
               surfaceTintColor: Colors.transparent,
             ),
           ),


### PR DESCRIPTION
## Summary
- replace deprecated DialogTheme assignments with DialogThemeData in the app theme and date picker override to match the latest Flutter Material 3 API.

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9c5c63aa08327af066a9f9523091b