### PR TITLE
Fix dialog theme usage for updated Material 3 API

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'home_screen.dart';
 import 'screens/splash_screen.dart';
 import 'screens/usuario_screen.dart';
 import 'screens/actualizar_token_screen.dart';
+import 'theme/dialog_theme.dart';
 
 final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
@@ -157,9 +158,7 @@ class SansebasSmsApp extends StatelessWidget {
       theme: ThemeData(
         colorSchemeSeed: Colors.green,
         useMaterial3: true,
-        dialogTheme: const DialogThemeData(
-          surfaceTintColor: Colors.transparent,
-        ),
+        dialogTheme: transparentDialogTheme,
       ),
       routes: {
         '/usuario': (_) => const UsuarioScreen(),

--- a/lib/screens/areapersonal_screen.dart
+++ b/lib/screens/areapersonal_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import '../theme/dialog_theme.dart';
 import 'mis_peticiones_screen.dart';
 import 'report_mensajes_screen.dart';
 
@@ -50,9 +51,7 @@ class _AreaPersonalScreenState extends State<AreaPersonalScreen> {
               onSurface: Colors.black,
               primary: scheme.primary,
             ),
-            dialogTheme: const DialogThemeData(
-              surfaceTintColor: Colors.transparent,
-            ),
+            dialogTheme: transparentDialogTheme,
           ),
           child: child,
         );

--- a/lib/theme/dialog_theme.dart
+++ b/lib/theme/dialog_theme.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+
+/// Common dialog theme ensuring Material 3 dialogs do not get a default surface tint.
+const DialogThemeData transparentDialogTheme = DialogThemeData(
+  surfaceTintColor: Colors.transparent,
+);


### PR DESCRIPTION
## Summary
- add a shared `DialogThemeData` definition without a surface tint
- reuse the shared dialog theme in the app theme and date picker override

## Testing
- flutter analyze *(fails: `flutter` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9c713a3bc83279e860909f37293a0