### PR TITLE
Add Mis peticiones screen and navigation

### DIFF
--- a/lib/screens/areapersonal_screen.dart
+++ b/lib/screens/areapersonal_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
+import 'mis_peticiones_screen.dart';
 import 'report_mensajes_screen.dart';
 
 class AreaPersonalScreen extends StatefulWidget {
@@ -99,6 +100,22 @@ class _AreaPersonalScreenState extends State<AreaPersonalScreen> {
                 )
               : const Icon(Icons.chevron_right),
           onTap: _guardando ? null : _solicitarDiaLibre,
+        ),
+      ),
+      Card(
+        child: ListTile(
+          leading: const Icon(Icons.list_alt),
+          title: const Text('Mis peticiones'),
+          subtitle:
+              const Text('Ver historial y cancelar las pendientes'),
+          trailing: const Icon(Icons.chevron_right),
+          onTap: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (_) => const MisPeticionesScreen(),
+              ),
+            );
+          },
         ),
       ),
       Card(

--- a/lib/screens/mis_peticiones_screen.dart
+++ b/lib/screens/mis_peticiones_screen.dart
@@ -1,0 +1,123 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class MisPeticionesScreen extends StatelessWidget {
+  const MisPeticionesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) {
+      return Scaffold(
+        appBar: AppBar(title: const Text('Mis peticiones')),
+        body: const Center(child: Text('Debes iniciar sesión')),
+      );
+    }
+
+    final query = FirebaseFirestore.instance
+        .collection('Peticiones')
+        .where('uid', isEqualTo: user.uid)
+        .orderBy('Fecha', descending: true); // índice compuesto requerido
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Mis peticiones')),
+      body: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
+        stream: query.snapshots(),
+        builder: (context, snap) {
+          if (snap.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snap.hasError) {
+            debugPrint('MisPeticiones error: ${snap.error}');
+            return const Center(child: Text('Error al cargar las peticiones.'));
+          }
+
+          final docs = snap.data?.docs ?? [];
+          if (docs.isEmpty) {
+            return const Center(child: Text('No tienes peticiones todavía.'));
+          }
+
+          return Scrollbar(
+            child: ListView.separated(
+              padding: const EdgeInsets.all(12),
+              itemCount: docs.length,
+              separatorBuilder: (_, __) => const SizedBox(height: 8),
+              itemBuilder: (_, i) {
+                final doc = docs[i];
+                final data = doc.data();
+                final estado = (data['Admitido'] ?? 'Pendiente').toString();
+                final fechaStr = _fmtFecha(data['Fecha']);
+                final cancelable = estado == 'Pendiente';
+
+                return Card(
+                  elevation: 1,
+                  child: ListTile(
+                    leading: const Icon(Icons.event_note),
+                    title: Text('Fecha: $fechaStr'),
+                    subtitle: Text('Estado: $estado'),
+                    trailing: cancelable
+                        ? TextButton.icon(
+                            onPressed: () => _cancelar(context, doc.id),
+                            icon: const Icon(Icons.cancel),
+                            label: const Text('Cancelar'),
+                          )
+                        : const Icon(Icons.lock_outline),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  static String _fmtFecha(dynamic ts) {
+    if (ts is Timestamp) {
+      return DateFormat('dd/MM/yyyy').format(ts.toDate());
+    }
+    if (ts is DateTime) {
+      return DateFormat('dd/MM/yyyy').format(ts);
+    }
+    return '(fecha no válida)';
+  }
+
+  Future<void> _cancelar(BuildContext context, String docId) async {
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Cancelar petición'),
+        content: const Text('¿Deseas cancelar esta petición pendiente?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('No'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.pop(context, true),
+            child: const Text('Sí'),
+          ),
+        ],
+      ),
+    );
+    if (ok != true) return;
+
+    try {
+      await FirebaseFirestore.instance.collection('Peticiones').doc(docId).delete();
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Petición cancelada.')),
+        );
+      }
+    } on FirebaseException catch (e) {
+      debugPrint('Error al cancelar petición $docId: ${e.message}');
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('No se pudo cancelar.')),
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a "Mis peticiones" entry in Área personal that routes to a new history screen
- implement MisPeticionesScreen to stream the user's petitions, format dates, and allow canceling pending ones with confirmation and feedback

## Testing
- flutter analyze *(fails: flutter command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9d4831e388327a3242e4af07e29f1