### PR TITLE
Fix leave request date picker visibility

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -148,6 +148,15 @@ class SansebasSmsApp extends StatelessWidget {
         primarySwatch: Colors.green,
         useMaterial3: true,
       ),
+      localizationsDelegates: const [
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [
+        Locale('es', 'ES'),
+        Locale('en', 'US'),
+      ],
       routes: {
         '/usuario': (_) => const UsuarioScreen(),
         '/actualizar-token': (_) => const ActualizarTokenScreen(),


### PR DESCRIPTION
## Summary
- force the leave request date picker to use a visible Material 3 theme and provide a bottom sheet fallback when the dialog fails to render
- share Firebase auth/firestore instances while keeping the saving state updates intact for leave requests
- configure the MaterialApp with Spanish and English localization delegates to support the picker locale

## Testing
- ⚠️ `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9d784e9d88327b66f7c419aded915