### PR TITLE
Fix missing Flutter localization imports

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:shared_preferences/shared_preferences.dart';


### PR DESCRIPTION
## Summary
- add the flutter_localizations package import so the localization delegates compile

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ca5101e5a083278f87132b60cb5933