### PR TITLE
Add flutter_localizations dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_localizations:
+    sdk: flutter
 
   firebase_core: ^4.0.0
   firebase_auth: ^6.0.1


### PR DESCRIPTION
## Summary
- add the flutter_localizations package to the app's dependencies so localization delegates resolve during build

## Testing
- `flutter pub get` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ca563f8df4832789bf267a51b09f44