### PR TITLE
Normaliza fechas locales en reportes

### DIFF
--- a/lib/screens/mis_peticiones_screen.dart
+++ b/lib/screens/mis_peticiones_screen.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:sansebassms/utils/datetime_local.dart';
 
 class MisPeticionesScreen extends StatelessWidget {
   const MisPeticionesScreen({super.key});
@@ -48,7 +48,7 @@ class MisPeticionesScreen extends StatelessWidget {
                 final doc = docs[i];
                 final data = doc.data();
                 final estado = (data['Admitido'] ?? 'Pendiente').toString();
-                final fechaStr = _fmtFecha(data['Fecha']);
+                final fechaStr = formatLocalDay(data['Fecha']);
                 final cancelable = estado == 'Pendiente';
 
                 return Card(
@@ -72,16 +72,6 @@ class MisPeticionesScreen extends StatelessWidget {
         },
       ),
     );
-  }
-
-  static String _fmtFecha(dynamic ts) {
-    if (ts is Timestamp) {
-      return DateFormat('dd/MM/yyyy').format(ts.toDate());
-    }
-    if (ts is DateTime) {
-      return DateFormat('dd/MM/yyyy').format(ts);
-    }
-    return '(fecha no válida)';
   }
 
   Future<void> _cancelar(BuildContext context, String docId) async {

--- a/lib/screens/report_mensajes_screen.dart
+++ b/lib/screens/report_mensajes_screen.dart
@@ -1,7 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+import 'package:sansebassms/utils/datetime_local.dart';
 
 class ReportMensajesScreen extends StatelessWidget {
   const ReportMensajesScreen({super.key});
@@ -73,18 +73,15 @@ class ReportMensajesScreen extends StatelessWidget {
                 final mensaje = (data['mensaje'] as String?)?.trim();
                 final telefono = (data['telefono'] as String?)?.trim();
                 final estado = (data['estado'] as String?)?.trim();
-                final fechaHora = data['fechaHora'];
-
-                DateTime? fecha;
-                if (fechaHora is Timestamp) {
-                  fecha = fechaHora.toDate();
-                } else if (fechaHora is DateTime) {
-                  fecha = fechaHora;
-                }
-
-                final fechaFormateada = fecha != null
-                    ? DateFormat('dd/MM/yyyy HH:mm').format(fecha)
-                    : 'Fecha desconocida';
+                final fecha = formatLocal(data['fechaHora']);
+                assert(() {
+                  final dt = toLocalDate(data['fechaHora']);
+                  // ignore: avoid_print
+                  print(
+                    "[DEBUG] uid=${data['uid']} fechaHoraUTC=${(data['fechaHora'] as Timestamp?)?.toDate()} local=$dt",
+                  );
+                  return true;
+                }());
 
                 return Card(
                   child: ListTile(
@@ -101,7 +98,7 @@ class ReportMensajesScreen extends StatelessWidget {
                         else
                           const Text('Teléfono no disponible'),
                         Text('Estado: ${estado?.isNotEmpty == true ? estado! : 'Desconocido'}'),
-                        Text('Fecha: $fechaFormateada'),
+                        Text('Fecha: $fecha'),
                       ],
                     ),
                     isThreeLine: true,

--- a/lib/utils/datetime_local.dart
+++ b/lib/utils/datetime_local.dart
@@ -1,0 +1,35 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:intl/intl.dart';
+
+/// Normaliza cualquier valor (Timestamp/DateTime/String) a DateTime local.
+DateTime? toLocalDate(dynamic value) {
+  if (value == null) return null;
+
+  if (value is Timestamp) {
+    return value.toDate().toLocal();
+  }
+  if (value is DateTime) {
+    return value.isUtc ? value.toLocal() : value;
+  }
+  if (value is String) {
+    // Si viene con 'Z' es UTC iso8601; si no, asumimos local.
+    final dt = DateTime.tryParse(value);
+    if (dt == null) return null;
+    return dt.isUtc ? dt.toLocal() : dt;
+  }
+  return null;
+}
+
+/// Formatea en dd/MM/yyyy HH:mm en hora local.
+String formatLocal(dynamic value) {
+  final dt = toLocalDate(value);
+  if (dt == null) return '(sin fecha)';
+  return DateFormat('dd/MM/yyyy HH:mm').format(dt);
+}
+
+/// Solo fecha (para Peticiones)
+String formatLocalDay(dynamic value) {
+  final dt = toLocalDate(value);
+  if (dt == null) return '(fecha no válida)';
+  return DateFormat('dd/MM/yyyy').format(dt);
+}


### PR DESCRIPTION
## Summary
- añadir utilidades compartidas para normalizar y formatear fechas en hora local
- reutilizar los formatos en las pantallas de ReportMensajes y MisPeticiones, incluyendo trazas de depuración en debug

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ca7b09a12083279f7ae3e91751db2a