### PR TITLE
Fix missing date formatter for MisPeticiones screen

### DIFF
--- a/lib/utils/datetime_local.dart
+++ b/lib/utils/datetime_local.dart
@@ -54,6 +54,12 @@ String formatLocal(dynamic value) {
   return DateFormat('dd/MM/yyyy HH:mm').format(dt);
 }
 
+String formatLocalDay(dynamic value) {
+  final dt = toLocalDate(value);
+  if (dt == null) return '(sin fecha)';
+  return DateFormat('dd/MM/yyyy').format(dt);
+}
+
 String formatLocalFromDayHour(dynamic dia, dynamic hora) {
   final dt = combineLocalDayHour(dia, hora);
   if (dt == null) return '(sin fecha)';


### PR DESCRIPTION
## Summary
- add a date-only formatter helper used by the petitions list

## Testing
- flutter analyze *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68ca9c4d28f48327b97cfb76d9e54211